### PR TITLE
 feat(calibration): add tasks for applying phase corrections to stacked data 

### DIFF
--- a/ch_pipeline/analysis/calibration.py
+++ b/ch_pipeline/analysis/calibration.py
@@ -1747,7 +1747,7 @@ class CalibrationCorrection(task.SingleTask):
     """
 
     rotation = config.Property(proptype=float, default=-0.088)
-    name_of_flag = config.Property(proptype=str, default='')
+    name_of_flag = config.Property(proptype=str, default="")
 
     def setup(self):
         """Query the database for all DataFlags with name equal to the `name_of_flag` property."""
@@ -1759,16 +1759,22 @@ class CalibrationCorrection(task.SingleTask):
             flag_types = finder.DataFlagType.select()
             for ft in flag_types:
                 if ft.name == self.name_of_flag:
-                    ftemp = list(finder.DataFlag.select().where(finder.DataFlag.type == ft))
+                    ftemp = list(
+                        finder.DataFlag.select().where(finder.DataFlag.type == ft)
+                    )
                     # Only keep flags that will produce nonzero corrections, as defined by
                     # the _correction_is_nonzero method
-                    flags += [flg for flg in ftemp if self._correction_is_nonzero(**flg.metadata)]
+                    flags += [
+                        flg
+                        for flg in ftemp
+                        if self._correction_is_nonzero(**flg.metadata)
+                    ]
 
         # Share flags with other nodes
         flags = self.comm.bcast(flags, root=0)
 
         # Save flags to class attribute
-        self.log.info('Found %d %s flags in total.' % (len(flags), self.name_of_flag))
+        self.log.info("Found %d %s flags in total." % (len(flags), self.name_of_flag))
         self.flags = flags
 
     def process(self, sstream, inputmap):
@@ -1788,10 +1794,12 @@ class CalibrationCorrection(task.SingleTask):
             The input container with the correction applied.
         """
         # Determine if there are flags pertinent to this range of time
-        if 'ra' in sstream.index_map:
+        if "ra" in sstream.index_map:
             ra = sstream.ra
-            csd = sstream.attrs['lsd'] if 'lsd' in sstream.attrs else sstream.attrs['csd']
-            if hasattr(csd, '__iter__'):
+            csd = (
+                sstream.attrs["lsd"] if "lsd" in sstream.attrs else sstream.attrs["csd"]
+            )
+            if hasattr(csd, "__iter__"):
                 csd = sorted(csd)[len(csd) // 2]
             timestamp = ephemeris.csd_to_unix(csd + ra / 360.0)
         else:
@@ -1809,7 +1817,7 @@ class CalibrationCorrection(task.SingleTask):
             return sstream
 
         # We are covered by the flags, so set up for correction
-        sstream.redistribute('freq')
+        sstream.redistribute("freq")
 
         # Determine local dimensions
         nfreq, nstack, ntime = sstream.vis.local_shape
@@ -1821,16 +1829,19 @@ class CalibrationCorrection(task.SingleTask):
         freq = sstream.freq[sfreq:efreq]
 
         # Extract representative products for the stacked visibilities
-        stack_new, stack_flag = tools.redefine_stack_index_map(inputmap, sstream.prod,
-                                                               sstream.stack,
-                                                               sstream.reverse_map['stack'])
+        stack_new, stack_flag = tools.redefine_stack_index_map(
+            inputmap, sstream.prod, sstream.stack, sstream.reverse_map["stack"]
+        )
         do_not_apply = np.flatnonzero(~stack_flag)
-        prod = sstream.prod[stack_new['prod']].copy()
+        prod = sstream.prod[stack_new["prod"]].copy()
 
         # Swap the product pair order for conjugated stack indices
-        cj = np.flatnonzero(stack_new['conjugate'].astype(np.bool))
+        cj = np.flatnonzero(stack_new["conjugate"].astype(np.bool))
         if cj.size > 0:
-            prod['input_a'][cj], prod['input_b'][cj] = prod['input_b'][cj], prod['input_a'][cj]
+            prod["input_a"][cj], prod["input_b"][cj] = (
+                prod["input_b"][cj],
+                prod["input_a"][cj],
+            )
 
         # Loop over flags again
         for flag in self.flags:
@@ -1838,23 +1849,34 @@ class CalibrationCorrection(task.SingleTask):
             in_range = (timestamp >= flag.start_time) & (timestamp <= flag.finish_time)
             if np.any(in_range):
 
-                msg = ('%d (of %d) samples require phase correction according to '
-                       '%s DataFlag covering %s to %s.' %
-                       (np.sum(in_range), in_range.size, self.name_of_flag,
-                        ephemeris.unix_to_datetime(flag.start_time).strftime("%Y%m%dT%H%M%SZ"),
-                        ephemeris.unix_to_datetime(flag.finish_time).strftime("%Y%m%dT%H%M%SZ")
-                        )
-                       )
+                msg = (
+                    "%d (of %d) samples require phase correction according to "
+                    "%s DataFlag covering %s to %s."
+                    % (
+                        np.sum(in_range),
+                        in_range.size,
+                        self.name_of_flag,
+                        ephemeris.unix_to_datetime(flag.start_time).strftime(
+                            "%Y%m%dT%H%M%SZ"
+                        ),
+                        ephemeris.unix_to_datetime(flag.finish_time).strftime(
+                            "%Y%m%dT%H%M%SZ"
+                        ),
+                    )
+                )
 
                 self.log.info(msg)
 
-                correction = self._get_correction(freq, prod, timestamp[in_range],
-                                                  inputmap, **flag.metadata)
+                correction = self._get_correction(
+                    freq, prod, timestamp[in_range], inputmap, **flag.metadata
+                )
 
                 if do_not_apply.size > 0:
-                    self.log.warning("Do not have valid baseline distance for stack indices: %s" %
-                                     str(do_not_apply))
-                    correction[:, do_not_apply, :] = 1.0 + 0.0J
+                    self.log.warning(
+                        "Do not have valid baseline distance for stack indices: %s"
+                        % str(do_not_apply)
+                    )
+                    correction[:, do_not_apply, :] = 1.0 + 0.0j
 
                 sstream.vis[:, :, in_range] *= correction
 
@@ -1877,17 +1899,19 @@ class CorrectTimeOffset(CalibrationCorrection):
         The name of the DataFlag that contains the time offset.
     """
 
-    name_of_flag = config.Property(proptype=str, default='calibration_time_offset')
+    name_of_flag = config.Property(proptype=str, default="calibration_time_offset")
 
     def _correction_is_nonzero(self, **kwargs):
-        return kwargs['time_offset'] != 0.0
+        return kwargs["time_offset"] != 0.0
 
     def _get_correction(self, freq, prod, timestamp, inputmap, **kwargs):
 
-        time_offset = kwargs['time_offset']
-        calibrator = kwargs['calibrator']
-        self.log.info("Applying a phase correction for a %0.2f second "
-                      "time offset on the calibrator %s." % (time_offset, calibrator))
+        time_offset = kwargs["time_offset"]
+        calibrator = kwargs["calibrator"]
+        self.log.info(
+            "Applying a phase correction for a %0.2f second "
+            "time offset on the calibrator %s." % (time_offset, calibrator)
+        )
 
         body = ephemeris.source_dictionary[calibrator]
 
@@ -1909,8 +1933,9 @@ class CorrectTimeOffset(CalibrationCorrection):
 
         # Calculate and return the phase correction, which is old offset minus new time offset
         # since we previously divided the chimestack data by the response to the calibrator.
-        correction = tools.fringestop_phase( ha, lat, dec, *uv) * tools.invert_no_zero(
-                     tools.fringestop_phase(0.0, lat, dec, *uv))
+        correction = tools.fringestop_phase(ha, lat, dec, *uv) * tools.invert_no_zero(
+            tools.fringestop_phase(0.0, lat, dec, *uv)
+        )
 
         return correction[:, :, np.newaxis]
 
@@ -1925,19 +1950,23 @@ class CorrectTelescopeRotation(CalibrationCorrection):
         used was during calibration.
     """
 
-    name_of_flag = config.Property(proptype=str, default='calibration_telescope_rotation')
+    name_of_flag = config.Property(
+        proptype=str, default="calibration_telescope_rotation"
+    )
 
     def _correction_is_nonzero(self, **kwargs):
-        return kwargs['rotation'] != self.rotation
+        return kwargs["rotation"] != self.rotation
 
     def _get_correction(self, freq, prod, timestamp, inputmap, **kwargs):
 
-        rotation = kwargs['rotation']
-        calibrator = kwargs['calibrator']
+        rotation = kwargs["rotation"]
+        calibrator = kwargs["calibrator"]
 
-        self.log.info("Applying a phase correction to convert from a telescope rotation "
-                      "of %0.3f deg to %0.3f deg for the calibrator %s." %
-                      (rotation, self.rotation, calibrator))
+        self.log.info(
+            "Applying a phase correction to convert from a telescope rotation "
+            "of %0.3f deg to %0.3f deg for the calibrator %s."
+            % (rotation, self.rotation, calibrator)
+        )
 
         body = ephemeris.source_dictionary[calibrator]
 
@@ -1961,8 +1990,9 @@ class CorrectTelescopeRotation(CalibrationCorrection):
 
         # Calculate and return the phase correction, which is old positions minus new positions
         # since we previously divided the chimestack data by the response to the calibrator.
-        correction = tools.fringestop_phase(0.0, lat, dec, *old_uv) * tools.invert_no_zero(
-                     tools.fringestop_phase(0.0, lat, dec, *current_uv))
+        correction = tools.fringestop_phase(
+            0.0, lat, dec, *old_uv
+        ) * tools.invert_no_zero(tools.fringestop_phase(0.0, lat, dec, *current_uv))
 
         return correction[:, :, np.newaxis]
 
@@ -1970,7 +2000,7 @@ class CorrectTelescopeRotation(CalibrationCorrection):
 def _calculate_uv(freq, prod, inputmap):
     """Generate baseline distances in wavelengths from the frequency, products, and inputmap."""
     feedpos = tools.get_feed_positions(inputmap).T
-    dist = feedpos[:, prod['input_a']] - feedpos[:, prod['input_b']]
+    dist = feedpos[:, prod["input_a"]] - feedpos[:, prod["input_b"]]
 
     lmbda = speed_of_light * 1e-6 / freq
     uv = dist[:, np.newaxis, :] / lmbda[np.newaxis, :, np.newaxis]


### PR DESCRIPTION
Introduces three new tasks:
- CalibrationCorrection is base class for applying a multiplicative correction to data based on parameters stored in the metadata of a DataFlag
- CorrectTimeOffset is a subclass that applies a phase correction for incorrect time standards used at the time of calibration
- CorrectTelescopeRotation is a subclass that applies a phase correction for incorrect telescope rotation used at the time of calibration

Dependent on pull request [ch_util #282](https://bitbucket.org/chime/ch_util/pull-requests/282/feat-tools-add-method/diff)

This PR was ported from bitbucket.