### PR TITLE
 fix(mapmaker,sidereal,io): fixes string problems that arise in python 2. 

### DIFF
--- a/ch_pipeline/analysis/sidereal.py
+++ b/ch_pipeline/analysis/sidereal.py
@@ -32,10 +32,10 @@ Generally you would want to use these tasks together. Starting with a
 from __future__ import absolute_import, division, print_function, unicode_literals
 from future.builtins import *  # noqa  pylint: disable=W0401, W0614
 from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
+from past.builtins import basestring
 
 # === End Python 2/3 compatibility
 
-from past.builtins import basestring
 import gc
 import numpy as np
 

--- a/ch_pipeline/core/io.py
+++ b/ch_pipeline/core/io.py
@@ -44,6 +44,7 @@ Several tasks accept groups of files as arguments. These are specified in the YA
 from __future__ import absolute_import, division, print_function, unicode_literals
 from future.builtins import *  # noqa  pylint: disable=W0401, W0614
 from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
+from past.builtins import basestring
 
 # === End Python 2/3 compatibility
 
@@ -69,7 +70,7 @@ def _list_of_filelists(files):
 
     for filelist in files:
 
-        if isinstance(filelist, str):
+        if isinstance(filelist, basestring):
             filelist = glob.glob(filelist)
         elif isinstance(filelist, list):
             pass
@@ -84,7 +85,7 @@ def _list_or_glob(files):
     # Take in a list of lists/glob patterns of filenames
     import glob
 
-    if isinstance(files, str):
+    if isinstance(files, basestring):
         files = sorted(glob.glob(files))
     elif isinstance(files, list):
         pass


### PR DESCRIPTION
- Use `basestring` from `past.builtins` to check for instances of strings.
- Use `np.string_` datatype for the ringmap `pol` axis to prevent errors writing to hdf5 in python 2.