### PR TITLE
Dataquery io changes

### DIFF
--- a/ch_pipeline/analysis/weather.py
+++ b/ch_pipeline/analysis/weather.py
@@ -1,0 +1,57 @@
+"""Module for thermal model stuff"""
+
+
+import numpy as np
+
+from caput import config, mpiutil, mpiarray, tod
+
+from ch_util import ephemeris
+# from ..core import task, containers, io
+from .sidereal import SiderealGrouper
+
+class WeatherGrouper(SiderealGrouper):
+    """Group Weather files together, slice the files at the correct timestamps
+    including the specified padding."""
+
+    def _process_current_lsd(self):
+        # Check if we have weather data for this day.
+        if len(self._timestream_list) == 0:
+            self.log.info("No weather data for this sidereal day")
+            return None
+
+        # Check if there is data missing
+        # Calculate the length of data in this current LSD
+        start = self._timestream_list[0].time[0]
+        end = self._timestream_list[-1].time[-1]
+        sid_seconds = 86400. / ephemeris.SIDEREAL_S
+
+        if (end - start) < (sid_seconds + 2 * self.padding):
+            self.log.info("Not enough weather data - skipping this day")
+            return None
+
+        lsd = self._current_lsd
+
+        # Convert the current lsd day to unix time and pad it.
+        unix_start = self.observer.lsd_to_unix(lsd)
+        unix_end = self.observer.lsd_to_unix(lsd + 1)
+        self.pad_start = unix_start - self.padding
+        self.pad_end = unix_end + self.padding
+
+        times = np.concatenate([ts.time for ts in self._timestream_list])
+        start_ind = int(np.argmin(np.abs(times - self.pad_start)))
+        stop_ind = int(np.argmin(np.abs(times - self.pad_end)))
+
+        self.log.info("Constructing LSD:%i [%i files]",
+                      lsd, len(self._timestream_list))
+        # Concatenate timestreams
+        ts = tod.concatenate(self._timestream_list, start=start_ind, stop=stop_ind)
+
+        # Make sure that our timestamps of the concatenated files don't fall
+        # out of the requested lsd time span
+        if (ts.time[0] > unix_start) or (ts.time[-1] < unix_end):
+            return None
+
+        ts.attrs['tag'] = ('lsd_%i' % lsd)
+        ts.attrs['lsd'] = lsd
+
+        return ts

--- a/ch_pipeline/core/dataquery.py
+++ b/ch_pipeline/core/dataquery.py
@@ -194,7 +194,6 @@ class QueryDatabase(pipeline.TaskBase):
                 f.include_26m_obs(self.source_26m)
 
             results = f.get_results()
-            print(results)
             files = [ fname for result in results for fname in result[0] ]
             files.sort()
 

--- a/ch_pipeline/core/dataquery.py
+++ b/ch_pipeline/core/dataquery.py
@@ -66,7 +66,7 @@ import os
 from caput import mpiutil, pipeline, config
 from ch_util import tools, ephemeris
 
-_DEFAULT_NODE_SPOOF = {'cedar': '/project/rpp-krs/chime/chime_online/'}
+_DEFAULT_NODE_SPOOF = {'cedar_archive': '/project/rpp-krs/chime/chime_archive/'}
 
 class QueryDatabase(pipeline.TaskBase):
     """Find files from specified database queries.
@@ -83,8 +83,14 @@ class QueryDatabase(pipeline.TaskBase):
         start and end times to restrict the database search to
         can be in any format ensure_unix will support, including eg
             20190116T150323 and 2019-1-16 08:03:23 -7
-    instrument : string (default: 'chimestack')
-        data set to use
+    acqtype : string (default: 'corr')
+        Type of acquisition. Options for acqtype are: 'corr', 'hk', 'weather',
+        'rawadc', 'gain', 'flaginput', 'digitalgain'.
+    instrument : string (optional)
+        Set the instrument name. Common ArchiveInst names are: 'chimeN2',
+        'chimestack', 'chime26m', 'chimetiming', 'chimecal', 'mingun' etc.
+        While acqtype returns all 'corr' data, one must specify the instrument
+        to get e.g. only stacked data (i.e. instrument = 'chimestack')
     source_26m : string (default: None)
         holography source to include. If None, do not include holography data.
     exclude_daytime : bool (default: False)
@@ -110,7 +116,9 @@ class QueryDatabase(pipeline.TaskBase):
     
     node_spoof = config.Property(proptype=dict, default=_DEFAULT_NODE_SPOOF)
     
-    instrument = config.Property(proptype=str, default='chimestack')
+    acqtype = config.Property(proptype=str, default='corr')
+    instrument = config.Property(proptype=str, default=None)
+
     source_26m = config.Property(proptype=str, default=None)
     
     start_time = config.Property(default=None)
@@ -155,23 +163,23 @@ class QueryDatabase(pipeline.TaskBase):
             
             f = di.Finder(node_spoof = self.node_spoof)
 
-            # should be redundant if an instrument has been specified
-            f.only_corr()
-            
+            f.filter_acqs(di.AcqType.name == self.acqtype)
+
+            if self.instrument is not None:
+                f.filter_acqs(di.ArchiveInst.name == self.instrument)
+
             if self.accept_all_global_flags:
                 f.accept_all_global_flags()
-            
+
             # Note: include_time_interval includes the specified time interval
             # Using this instead of set_time_range, which only narrows the interval
             # f.include_time_interval(self.start_time, self.end_time)
             f.set_time_range(self.start_time, self.end_time)
-            
+
             if self.start_RA and self.end_RA:
                 f.include_RA_interval(self.start_RA, self.end_RA)
             elif (self.start_RA or self.start_RA):
                     print('WARNING: one but not both of start_RA and end_RA are set. Ignoring both.')
-            
-            f.filter_acqs(di.ArchiveInst.name == self.instrument)
             
             if self.exclude_daytime:
                 f.exclude_daytime()
@@ -184,9 +192,9 @@ class QueryDatabase(pipeline.TaskBase):
            
             if self.source_26m:
                 f.include_26m_obs(self.source_26m)
-                
-            
+
             results = f.get_results()
+            print(results)
             files = [ fname for result in results for fname in result[0] ]
             files.sort()
 

--- a/ch_pipeline/core/io.py
+++ b/ch_pipeline/core/io.py
@@ -245,49 +245,8 @@ class LoadDataFiles(task.SingleTask):
         return ts
 
 
+# For backwards compatibility
 LoadCorrDataFiles = LoadDataFiles
-
-
-class LoadWeatherFiles(task.SingleTask):
-    """Task to load weather files"""
-
-    files = None
-    _file_ptr = 0
-
-    def setup(self, files):
-        """Set the list of files to load.
-
-        Parameters
-        ----------
-        files : list
-        """
-        if not isinstance(files, (list, tuple)):
-            raise RuntimeError('Argument must be list of files.')
-
-        self.files = files
-
-    def process(self):
-        """ Load in each weather file
-
-        Returns
-        -------
-        ts : andata.WeatherData
-        """
-        if len(self.files) == self._file_ptr:
-            raise pipeline.PipelineStopIteration
-
-        # Collect garbage to remove any prior CorrData objects
-        gc.collect()
-        # Fetch and remove the first item in the list
-        file_ = self.files[self._file_ptr]
-        self._file_ptr += 1
-
-        # Load file
-        self.log.info("Reading file %i of %i. (%s)", self._file_ptr, len(self.files), file_)
-
-        ts = andata.WeatherData.from_acq_h5(file_)
-
-        return ts
 
 
 class LoadSetupFile(pipeline.TaskBase):


### PR DESCRIPTION
- changes to pipeline to be able to handle other data than just 'corr'
- some fixes

This pull request is for having a more flexible QueryDatabase task and a more flexible LoadDataFiles (used to be LoadCorrDataFiles). It supports now additionally to CorrData, HKData, HKPData, WeatherData, RawADCData, GainFlagData.

Additionally, there is a WeatherGrouper, that allows the user of the pipeline to concatenate weather files exactly to the length of an LSD (+/- padding)