### PR TITLE
ringmap xpol

### DIFF
--- a/ch_pipeline/analysis/mapmaker.py
+++ b/ch_pipeline/analysis/mapmaker.py
@@ -216,7 +216,7 @@ class RingMapMaker(task.SingleTask):
         # of the variance in the visibilities
         rm.rms[:] = np.sqrt(
             2 * np.sum(tools.invert_no_zero(invvar) * weight ** 2.0, axis=(-2, -1))
-        )
+        ).transpose(1, 0, 2)
 
         # Dereference datasets
         rmm = rm.map[:]

--- a/ch_pipeline/core/containers.py
+++ b/ch_pipeline/core/containers.py
@@ -607,7 +607,7 @@ class RingMap(ContainerBase):
             "distributed_axis": "freq",
         },
         "rms": {
-            "axes": ["freq", "pol", "ra"],
+            "axes": ["pol", "freq", "ra"],
             "dtype": np.float64,
             "initialise": False,
             "distributed": True,


### PR DESCRIPTION
I've checked that the datasets `ringmap`, `rms`, and `dirty_beam` produced with this branch are identical to those made with the old code (up to difference ~1e-10 in some cases). I checked this with the options
```
single_beam: Yes
weight: natural
exclude_intracyl: Yes/No
include_auto: No
```
and I'm running a test with multiple beams right now, and including the autos afterwards.

Things I changed apart from the cross-pol maps is to simplify the normalization a bit (should be the same), and attempt some performance improvements by reducing some array creation steps I hope. I also changed how the multiple beam case is handled: Taking a complex instead of complex-to-real FFT. I still need to verify these are equivalent.