### PR TITLE
fix(source_removal): handle csd of sidereal stacks properly

### DIFF
--- a/ch_pipeline/analysis/source_removal.py
+++ b/ch_pipeline/analysis/source_removal.py
@@ -533,6 +533,7 @@ class SubtractSources(task.SingleTask):
         # Calculate time
         if "ra" in data.index_map:
             csd = data.attrs["lsd"] if "lsd" in data.attrs else data.attrs["csd"]
+            csd = np.fix(np.mean(csd))
             timestamp = ephemeris.csd_to_unix(csd + data.ra / 360.0)
         elif "time" in data.index_map:
             timestamp = data.time


### PR DESCRIPTION
Previously we had assumed that the csd attribute is a scalar, but in
the case of sidereal stacks it is a list.