### PR TITLE
ss/tel rotation

### DIFF
--- a/ch_pipeline/analysis/calibration.py
+++ b/ch_pipeline/analysis/calibration.py
@@ -632,7 +632,7 @@ class EigenCalibration(task.SingleTask):
     max_hour_angle = config.Property(proptype=float, default=10.0)
     window = config.Property(proptype=float, default=0.75)
     dyn_rng_threshold = config.Property(proptype=float, default=3.0)
-    telescope_rotation = config.Property(proptype=float, default=-0.088)
+    telescope_rotation = config.Property(proptype=float, default=tools._CHIME_ROT)
 
     def process(self, data, inputmap):
         """Determine feed response from eigendecomposition.
@@ -1740,13 +1740,13 @@ class CalibrationCorrection(task.SingleTask):
 
     Parameters
     ----------
-    rotation : bool
+    rotation : float
         Current best estimate of telescope rotation.
     name_of_flag : str
         The name of the DataFlag.
     """
 
-    rotation = config.Property(proptype=float, default=-0.088)
+    rotation = config.Property(proptype=float, default=tools._CHIME_ROT)
     name_of_flag = config.Property(proptype=str, default="")
 
     def setup(self):

--- a/ch_pipeline/analysis/fringestop.py
+++ b/ch_pipeline/analysis/fringestop.py
@@ -50,10 +50,14 @@ class FringeStop(task.SingleTask):
     overwrite : bool
         Whether overwrite the original timestream data with the fringestopped
         timestream data, default is False
+    telescope_rotation : float
+        Rotation of the telescope from true north in degrees.  A positive rotation is
+        anti-clockwise when looking down at the telescope from the sky.
     """
 
     source = config.Property(proptype=str)
     overwrite = config.Property(proptype=bool, default=False)
+    telescope_rotation = config.Property(proptype=float, default=tools._CHIME_ROT)
 
     def process(self, tstream, inputmap):
         """Apply the fringe stop of CHIME data to a given source
@@ -80,8 +84,12 @@ class FringeStop(task.SingleTask):
         freq = tstream.freq[start_freq:end_freq]
         prod_map = tstream.index_map["prod"][tstream.index_map["stack"]["prod"]]
         src = ephemeris.source_dictionary[self.source]
+
+        # Rotate the telescope
+        tools.change_chime_location(rotation=self.telescope_rotation)
         feeds = [inputmap[tstream.input[i][0]] for i in range(len(tstream.input))]
 
+        # Fringestop
         fs_vis = tools.fringestop_time(
             tstream.vis,
             times=tstream.time,
@@ -90,6 +98,9 @@ class FringeStop(task.SingleTask):
             src=src,
             prod_map=prod_map,
         )
+
+        # Return telescope to default rotation
+        tools.change_chime_location(default=True)
 
         if self.overwrite:
             tstream.vis[:] = fs_vis

--- a/ch_pipeline/analysis/source_removal.py
+++ b/ch_pipeline/analysis/source_removal.py
@@ -262,7 +262,7 @@ class SolveSources(task.SingleTask):
 
     min_altitude = config.Property(proptype=float, default=10.0)
     min_distance = config.Property(proptype=float, default=20.0)
-    telescope_rotation = config.Property(proptype=float, default=-0.088)
+    telescope_rotation = config.Property(proptype=float, default=tools._CHIME_ROT)
     max_iter = config.Property(proptype=int, default=4)
 
     def setup(self, tel):

--- a/ch_pipeline/core/telescope.py
+++ b/ch_pipeline/core/telescope.py
@@ -225,11 +225,13 @@ class CHIME(telescope.PolarisedTelescope):
     def v_width(self):
         return 1.0
 
-    # Set non-zero rotation angle for pathfinder
+    # Set non-zero rotation angle for pathfinder and chime
     @property
     def rotation_angle(self):
         if self.correlator == "pathfinder":
             return tools._PF_ROT
+        elif self.correlator == "chime":
+            return tools._CHIME_ROT
         else:
             return 0.0
 


### PR DESCRIPTION
Sets the default telescope rotation throughout the package to `ch_util.tools._CHIME_ROT`.

Adds capability to use a different telescope rotation via config property to the `analysis.fringestop.FringeStop` task.