### PR TITLE
ci: fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 language: python
 os: linux
 sudo: required
-dist: xenial
+dist: bionic
+
+addons:
+    apt:
+        packages:
+            - libhdf5-serial-dev
+            - libopenmpi-dev
+            - openmpi-bin
 
 python:
-    - 3.7
+    - 3.8
 notifications:
     email: false
-addons:
-    ssh_known_hosts:
-        - bitbucket.org
 
 before_install:
     - pip install future # nedded for caput setup


### PR DESCRIPTION
For some reason travis was failing with some MPI build issue. This explicitly installs openmpi to make it work.