### PR TITLE
docs(examples): fix some errors in the example configs

### DIFF
--- a/ch_pipeline/analysis/sidereal.py
+++ b/ch_pipeline/analysis/sidereal.py
@@ -10,7 +10,7 @@ Usage
 Generally you would want to use these tasks together. Starting with a
 :class:`LoadTimeStreamSidereal`, then feeding that into
 :class:`SiderealRegridder` to grid onto each sidereal day, and then into
-:class:`SiderealStacker` if you want to combine the different days.
+:class:`draco.analysis.SiderealStacker` if you want to combine the different days.
 """
 
 import gc

--- a/ch_pipeline/core/io.py
+++ b/ch_pipeline/core/io.py
@@ -41,66 +41,6 @@ from ch_util import andata
 from draco.core import task
 
 
-def _list_of_filelists(files):
-    # Take in a list of lists/glob patterns of filenames
-    import glob
-
-    f2 = []
-
-    for filelist in files:
-
-        if isinstance(filelist, str):
-            filelist = glob.glob(filelist)
-        elif isinstance(filelist, list):
-            pass
-        else:
-            raise Exception("Must be list or glob pattern.")
-        f2.append(filelist)
-
-    return f2
-
-
-def _list_or_glob(files):
-    # Take in a list of lists/glob patterns of filenames
-    import glob
-
-    if isinstance(files, str):
-        files = sorted(glob.glob(files))
-    elif isinstance(files, list):
-        pass
-    else:
-        raise RuntimeError("Must be list or glob pattern.")
-
-    return files
-
-
-def _list_of_filegroups(groups):
-    # Process a file group/groups
-    import glob
-
-    # Convert to list if the group was not included in a list
-    if not isinstance(groups, list):
-        groups = [groups]
-
-    # Iterate over groups, set the tag if needed, and process the file list
-    # through glob
-    for gi, group in enumerate(groups):
-
-        files = group["files"]
-
-        if "tag" not in group:
-            group["tag"] = "group_%i" % gi
-
-        flist = []
-
-        for fname in files:
-            flist += glob.glob(fname)
-
-        group["files"] = flist
-
-    return groups
-
-
 class LoadCorrDataFiles(task.SingleTask):
     """Load data from files passed into the setup routine.
 

--- a/examples/calibration_pipeline.yaml
+++ b/examples/calibration_pipeline.yaml
@@ -2,7 +2,7 @@
 # Peforms the same processing as the calibration broker (real-time pipeline).
 cluster:
     directory:          $SCRATCH/eigen_cal/cyg_a
-    venv:               /home/ssiegel/ch_pipeline/venv
+    venv:               my_venv
 
     ## Cluster configuration (ignored unless on a cluster)
     name:               cyga_winter             # Jobname
@@ -59,12 +59,9 @@ pipeline:
                 include_transits: *source
                 include_transits_time_delta: 7200.0
 
-        -   type:       ch_pipeline.analysis.sidereal.SiderealFileFilterFromParams
+        -   type:       ch_pipeline.analysis.sidereal.SiderealGrouper
             requires:   qfilelist
             out:        sfilelist
-            params:
-                csd_start:  *csd_start
-                csd_end:    *csd_end
 
         -   type: draco.core.io.LoadFilesFromParams
             out: tcorr

--- a/examples/construct_timing_correction.yaml
+++ b/examples/construct_timing_correction.yaml
@@ -1,7 +1,7 @@
 cluster:
     name:               tcorr
     directory:          $SCRATCH/timing/
-    venv:               /home/ssiegel/ch_pipeline/venv
+    venv:               my_venv
 
     ## Cluster configuration (ignored unless on a cluster)
     name:               tcorr                   # Jobname

--- a/examples/noise_calibration.yaml
+++ b/examples/noise_calibration.yaml
@@ -11,33 +11,33 @@ cluster:
 pipeline :
     tasks:
 
-        -   type:       ch_pipeline.dataquery.QueryRun
+        -   type:       ch_pipeline.core.dataquery.QueryRun
             out:        filelist
             params:
                 run_name:   "run_pass1_g"
 
-        -   type:       ch_pipeline.io.LoadCorrDataFiles
+        -   type:       ch_pipeline.core.io.LoadCorrDataFiles
             requires:   filelist
             out:        tstream
             
-        -   type:       ch_pipeline.dataquery.QueryInputs
+        -   type:       ch_pipeline.core.dataquery.QueryInputs
             in:         tstream
             out:        inputmap
 
-        -   type:       ch_pipeline.calibration.NoiseSourceFold
+        -   type:       ch_pipeline.analysis.calibration.NoiseSourceFold
             in:         tstream
             out:        foldedday
             params:
                 period:   2
-                phase:    1
+                phase:    [1]
 
-        -   type:       ch_pipeline.flagging.BadNodeFlagger
+        -   type:       ch_pipeline.analysis.flagging.BadNodeFlagger
             in:         foldedday
             out:        foldedday2
             params:
                 nodes:  [2, 6, 9, 10, 15]
 
-        -   type:       ch_pipeline.calibration.GatedNoiseCalibration
+        -   type:       ch_pipeline.analysis.calibration.GatedNoiseCalibration
             in:         [foldedday2, inputmap]
             out:        noisecalday
             params:

--- a/examples/noise_calibration.yaml
+++ b/examples/noise_calibration.yaml
@@ -6,7 +6,7 @@ cluster:
     ompnum:    8
     time:      120:00
 
-    venv:      /home/k/krs/jrs65/ch_pipeline/venv
+    venv:      my_venv
 
 pipeline :
     tasks:

--- a/examples/test.yaml
+++ b/examples/test.yaml
@@ -1,51 +1,33 @@
-
+---
 
 pipeline :
     tasks:
-        -   type:   ch_pipeline.sidereal.LoadTimeStreamSidereal
-            out:    siderealday
-            params: input_params
+        -   type:   draco.core.io.LoadFilesFromParams
+            out:    input_files
+            params:
+                files: testdata/*.h5
 
-        -   type:   ch_pipeline.rfi.RFIFilter
+        -   type:   ch_pipeline.analysis.sidereal.SiderealGrouper
+            out:    siderealday
+            in:     input_files
+
+        -   type:   ch_pipeline.analysis.flagging.RFIFilter
             in:     siderealday
             out:    maskedday
-            params: no_params
+            params:
+                save: true
+                output_name: rfi_filtered.h5
 
-        -   type:   ch_pipeline.io.SaveOutput
+        -   type:   ch_pipeline.analysis.sidereal.SiderealRegridder
             in:     maskedday
-            out:    maskedday2
-            params: save_params
-
-        -   type:   ch_pipeline.sidereal.SiderealRegridder
-            in:     maskedday2
             out:    sday
-            params: no_params
+            params:
+                save: true
+                output_name: sidereal_grid.h5
 
-        -   type:   ch_pipeline.io.SaveOutput
+        -   type:   draco.analysis.sidereal.SiderealStacker
             in:     sday
-            out:    sday2
-            params: save_params2
-
-        -   type:   ch_pipeline.sidereal.SiderealStacker
-            in:     sday2
             out:    sstack
-            params: no_params
-
-        -   type:   ch_pipeline.io.SaveOutput
-            in:     sstack
-            params: save_params3
-
-no_params: {}
-
-input_params:
-    filepat:    "testdata/*.h5"
-
-save_params:
-    root:   rfi_filtered
-
-save_params2:
-    root:   sidereal_grid
-
-
-save_params3:
-    root:   sidereal_stack
+            params:
+                save: true
+                output_name: sidereal_stack.h5

--- a/examples/test_dataflagger.yaml
+++ b/examples/test_dataflagger.yaml
@@ -1,6 +1,6 @@
 cluster:
     directory:          $SCRATCH/chime/pipeline/test/data_flagger
-    venv:               /home/ssiegel/ch_pipeline_master/venv
+    venv:               my_venv
 
     ## Cluster configuration (ignored unless on a cluster)
     name:               dataflagger             # Jobname
@@ -27,9 +27,9 @@ pipeline:
             out:        filelist
             params:
                 files:
-                    -   "/project/rpp-krs/chime/chime_online/20181220T235142Z_chimestack_corr/00000000_0000.h5"
-                    -   "/project/rpp-krs/chime/chime_online/20181220T235142Z_chimestack_corr/00040716_0000.h5"
-                    -   "/project/rpp-krs/chime/chime_online/20181220T235142Z_chimestack_corr/01603203_0000.h5"
+                    -   "/project/rpp-krs/chime/chime_online/20181220T235142Z_chimestack_corr/00000000_*.h5"
+                    -   "/project/rpp-krs/chime/chime_online/20181220T235142Z_chimestack_corr/00040716_*.h5"
+                    -   "/project/rpp-krs/chime/chime_online/20181220T235142Z_chimestack_corr/01603203_*.h5"
 
         -   type:       ch_pipeline.core.io.LoadCorrDataFiles
             requires:   filelist


### PR DESCRIPTION
They still don't all work. For example `ch_pipeline.core.io.SaveOutput` doesn't exist.

Depends on https://github.com/radiocosmology/caput/pull/147