### PR TITLE
Ch/timingerrors

### DIFF
--- a/ch_pipeline/synthesis/timingerrors.py
+++ b/ch_pipeline/synthesis/timingerrors.py
@@ -191,3 +191,12 @@ class TimingErrors(gain.BaseGains):
         self._prev_time = time
 
         return gain_phase
+
+
+class SiderealTimingErrors(TimingErrors, gain.SiderealGains):
+    """Generate sidereal timing errors gains on a sidereal grid.
+
+    See the documentation for `TimingErrors` and `SiderealGains` for more detail.
+    """
+
+    pass


### PR DESCRIPTION
A new class called `SiderealTimingErrors` was created in the module `timingerrors` in order to simulate gain errors on a sidereal grid. 