### PR TITLE
feat(telescope): update beam evaluation for use in beamformer code

### DIFF
--- a/ch_pipeline/analysis/calibration.py
+++ b/ch_pipeline/analysis/calibration.py
@@ -1811,7 +1811,7 @@ class ThermalCalibration(task.SingleTask):
         return gain
 
     def _ra2unix(self, csd, ra):
-        """ csd must be integer """
+        """csd must be integer"""
         return ephemeris.csd_to_unix(csd + ra / 360.0)
 
     def _reftime2gain(self, reftime_result, timestamp, frequency):

--- a/ch_pipeline/processing/beam.py
+++ b/ch_pipeline/processing/beam.py
@@ -121,7 +121,7 @@ pipeline:
 
 
 class HolographyFringestop(base.ProcessingType):
-    """"""
+    """ """
 
     type_name = "holo_fstop"
     # tag by name of source and processing run

--- a/ch_pipeline/processing/daily.py
+++ b/ch_pipeline/processing/daily.py
@@ -334,7 +334,7 @@ pipeline:
 
 
 class DailyProcessing(base.ProcessingType):
-    """"""
+    """ """
 
     type_name = "daily"
     tag_pattern = r"\d+"


### PR DESCRIPTION
- Add angpos as a keyword argument to the beam method of the CHIME telescope.
Enables evaluation of the beam along a single source track, which is required
for the beamformer.  If not provided, then it will default to the _angos
telescope attribute.

- CHIME telescope now uses fast methods for evaluating the cylinder beam that
involve cacheing pre-products in a class dictionary.  This will require the
[sf/fast-beam](https://github.com/radiocosmology/driftscan/tree/sf/fast-beam) branch of driftscan to be merged.

- Add dec_normalized config parameter to CHIME class that, if set, will
normalize the beam by its magnitude at the transit of the declination
provided. To mach CHIME calibration, the user would set this parameter
to the declination of Cyg A.

- Creates a CHIMEParameterizedBeam class that is a CHIME telescope whose
beam method evaluates Mateus' parameterized fit to the driftscan beam.