### PR TITLE
feat(io): add capabilities to file loading tasks

### DIFF
--- a/ch_pipeline/core/io.py
+++ b/ch_pipeline/core/io.py
@@ -292,18 +292,15 @@ class LoadSetupFile(io.BaseLoadFiles):
 class LoadFileFromTag(io.BaseLoadFiles):
     """Loads a file from disk into a memh5 container.
 
-    The suffix of the filename is extracted from the
-    tag of the input container.
+    The suffix of the filename is extracted from the tag of the input container.
 
     Attributes
     ----------
     prefix : str
-        Filename is assumed to have the format:
-            prefix + incont.attrs['tag'] + '.h5'
+        Filename is assumed to have the format: "{prefix}{incont.attrs['tag']}.h5"
     only_prefix : bool
-        If True, then the class will return the same container
-        at each iteration.  The filename is assumed to have the format:
-            prefix + '.h5'
+        If True, then the class will return the same container at each iteration.
+        The filename is assumed to have the format: "{prefix}.h5"
     """
 
     prefix = config.Property(proptype=str)


### PR DESCRIPTION
The LoadSetupFile and LoadFilesFromTag task are now
subclasses of draco.core.io.BaseLoadFiles.  This provides
these tasks with the capability to load distributed containers,
convert byte strings, and make selections along axes.

Depends on PR #135 of draco.