### PR TITLE
Frequency dependent FWHMs

### DIFF
--- a/ch_pipeline/core/telescope.py
+++ b/ch_pipeline/core/telescope.py
@@ -197,7 +197,9 @@ class CHIME(telescope.PolarisedTelescope):
     def fwhm_e(self):
         """Full width half max of the E-plane antenna beam."""
 
-        coeff_fwhm_input_Y = np.array([1.15310483e-07,-2.30462590e-04,1.50451290e-01,-3.07440520e+01])
+        coeff_fwhm_input_Y = np.array(
+            [1.15310483e-07, -2.30462590e-04, 1.50451290e-01, -3.07440520e01]
+        )
 
         fwhm_freq_Y = np.polyval(coeff_fwhm_input_Y, self.frequencies)
 
@@ -207,7 +209,9 @@ class CHIME(telescope.PolarisedTelescope):
     def fwhm_h(self):
         """Full width half max of the H-plane antenna beam."""
 
-        coeff_fwhm_input_X = np.array([2.97495306e-07,-6.00582101e-04,3.99949759e-01,-8.66733249e+01])
+        coeff_fwhm_input_X = np.array(
+            [2.97495306e-07, -6.00582101e-04, 3.99949759e-01, -8.66733249e01]
+        )
 
         fwhm_freq_X = np.polyval(coeff_fwhm_input_X, self.frequencies)
 

--- a/ch_pipeline/core/telescope.py
+++ b/ch_pipeline/core/telescope.py
@@ -196,9 +196,9 @@ class CHIME(telescope.PolarisedTelescope):
     @property
     def fwhm_e(self):
         """Full width half max of the E-plane antenna beam."""
-        coeff_fwhm_input_Y = np.array([2.41511275e-10,-6.71378830e-07,\
-        7.20183967e-04,-3.52472912e-01,6.73758644e+01])
-        
+
+        coeff_fwhm_input_Y = np.array([1.15310483e-07,-2.30462590e-04,1.50451290e-01,-3.07440520e+01])
+
         fwhm_freq_Y = np.polyval(coeff_fwhm_input_Y, self.frequencies)
 
         return fwhm_freq_Y
@@ -206,9 +206,9 @@ class CHIME(telescope.PolarisedTelescope):
     @property
     def fwhm_h(self):
         """Full width half max of the H-plane antenna beam."""
-        coeff_fwhm_input_X = np.array([ 2.86443038e-10,-7.79063706e-07,\
-        8.15859136e-04,-3.89137634e-01,7.23010129e+01])
-        
+
+        coeff_fwhm_input_X = np.array([2.97495306e-07,-6.00582101e-04,3.99949759e-01,-8.66733249e+01])
+
         fwhm_freq_X = np.polyval(coeff_fwhm_input_X, self.frequencies)
 
         return fwhm_freq_X

--- a/ch_pipeline/core/telescope.py
+++ b/ch_pipeline/core/telescope.py
@@ -18,7 +18,7 @@ from drift.core import telescope
 from drift.telescope import cylbeam
 
 from ch_util import ephemeris, tools
-
+from caput.cache import cached_property
 
 # Get the logger for the module
 logger = logging.getLogger(__name__)
@@ -199,27 +199,27 @@ class CHIME(telescope.PolarisedTelescope):
     #
 
     # Tweak the following two properties to change the beam width
-    @property
+    @cached_property
     def fwhm_ex(self):
-        """Full width half max of the E-plane antenna beam."""
+        """Full width half max of the E-plane antenna beam for X polarization."""
 
         return np.polyval(np.array(self._exwidth) * 2.0 * np.pi / 3.0, self.frequencies)
 
-    @property
+    @cached_property
     def fwhm_hx(self):
-        """Full width half max of the H-plane antenna beam."""
+        """Full width half max of the H-plane antenna beam for X polarization."""
 
         return np.polyval(np.array(self._hxwidth) * 2.0 * np.pi / 3.0, self.frequencies)
 
-    @property
+    @cached_property
     def fwhm_ey(self):
-        """Full width half max of the E-plane antenna beam."""
+        """Full width half max of the E-plane antenna beam for Y polarization."""
 
         return np.polyval(np.array(self._eywidth) * 2.0 * np.pi / 3.0, self.frequencies)
 
-    @property
+    @cached_property
     def fwhm_hy(self):
-        """Full width half max of the E-plane antenna beam."""
+        """Full width half max of the H-plane antenna beam for Y polarization."""
 
         return np.polyval(np.array(self._hywidth) * 2.0 * np.pi / 3.0, self.frequencies)
 
@@ -546,7 +546,7 @@ class CHIME(telescope.PolarisedTelescope):
         return beam_map, beam_mask
 
 
-class revisedDriftScan(CHIME):
+class CHIMEFitBeam(CHIME):
     """Driftscan model with revised FWHM for north-south beam.
 
     Point source beam model was fit to a flat Gaussian at each frequency.

--- a/ch_pipeline/core/telescope.py
+++ b/ch_pipeline/core/telescope.py
@@ -112,8 +112,11 @@ class CHIME(telescope.PolarisedTelescope):
     cylinder_width = 20.0
     cylinder_spacing = tools._PF_SPACE
 
-    _ewidth = [0.7]
-    _hwidth = [1.2]
+    _exwidth = [0.7]
+    _eywidth = _exwidth
+
+    _hxwidth = [1.2]
+    _hywidth = _hxwidth
 
     _pickle_keys = ["_feeds"]
 
@@ -197,16 +200,28 @@ class CHIME(telescope.PolarisedTelescope):
 
     # Tweak the following two properties to change the beam width
     @property
-    def fwhm_e(self):
+    def fwhm_ex(self):
         """Full width half max of the E-plane antenna beam."""
 
-        return np.polyval(np.array(self._ewidth) * 2.0 * np.pi / 3.0, self.frequencies)
+        return np.polyval(np.array(self._exwidth) * 2.0 * np.pi / 3.0, self.frequencies)
 
     @property
-    def fwhm_h(self):
+    def fwhm_hx(self):
         """Full width half max of the H-plane antenna beam."""
 
-        return np.polyval(np.array(self._hwidth) * 2.0 * np.pi / 3.0, self.frequencies)
+        return np.polyval(np.array(self._hxwidth) * 2.0 * np.pi / 3.0, self.frequencies)
+
+    @property
+    def fwhm_ey(self):
+        """Full width half max of the E-plane antenna beam."""
+
+        return np.polyval(np.array(self._eywidth) * 2.0 * np.pi / 3.0, self.frequencies)
+    
+    @property
+    def fwhm_hy(self):
+        """Full width half max of the E-plane antenna beam."""
+
+        return np.polyval(np.array(self._hywidth) * 2.0 * np.pi / 3.0, self.frequencies)
 
     # Set the approximate uv feed sizes
     @property
@@ -414,8 +429,8 @@ class CHIME(telescope.PolarisedTelescope):
                 self._angpos,
                 self.zenith,
                 self.cylinder_width / self.wavelengths[freq],
-                self.fwhm_e[freq],
-                self.fwhm_h[freq],
+                self.fwhm_ey[freq], 
+                self.fwhm_hy[freq],
                 rot=rot,
             )
         elif tools.is_array_x(feed_obj):
@@ -423,8 +438,8 @@ class CHIME(telescope.PolarisedTelescope):
                 self._angpos,
                 self.zenith,
                 self.cylinder_width / self.wavelengths[freq],
-                self.fwhm_e[freq],
-                self.fwhm_h[freq],
+                self.fwhm_ex[freq], 
+                self.fwhm_hx[freq],
                 rot=rot,
             )
         else:
@@ -544,19 +559,18 @@ class revisedDriftScan(CHIME):
     This model will produce large extrapolation errors if used below that.
     """
 
-    _ewidth = (
+    _eywidth = (
         3.0
         / (2 * np.pi)
         * np.array([1.15310483e-07, -2.30462590e-04, 1.50451290e-01, -3.07440520e01])
     )
 
-    _hwidth = (
+    _hxwidth = (
         3.0
         / (2 * np.pi)
         * np.array([2.97495306e-07, -6.00582101e-04, 3.99949759e-01, -8.66733249e01])
     )
-
-
+    
 class CHIMEExternalBeam(CHIME):
     """Model telescope for the CHIME.
 

--- a/ch_pipeline/core/telescope.py
+++ b/ch_pipeline/core/telescope.py
@@ -216,7 +216,7 @@ class CHIME(telescope.PolarisedTelescope):
         """Full width half max of the E-plane antenna beam."""
 
         return np.polyval(np.array(self._eywidth) * 2.0 * np.pi / 3.0, self.frequencies)
-    
+
     @property
     def fwhm_hy(self):
         """Full width half max of the E-plane antenna beam."""
@@ -429,7 +429,7 @@ class CHIME(telescope.PolarisedTelescope):
                 self._angpos,
                 self.zenith,
                 self.cylinder_width / self.wavelengths[freq],
-                self.fwhm_ey[freq], 
+                self.fwhm_ey[freq],
                 self.fwhm_hy[freq],
                 rot=rot,
             )
@@ -438,7 +438,7 @@ class CHIME(telescope.PolarisedTelescope):
                 self._angpos,
                 self.zenith,
                 self.cylinder_width / self.wavelengths[freq],
-                self.fwhm_ex[freq], 
+                self.fwhm_ex[freq],
                 self.fwhm_hx[freq],
                 rot=rot,
             )
@@ -570,7 +570,8 @@ class revisedDriftScan(CHIME):
         / (2 * np.pi)
         * np.array([2.97495306e-07, -6.00582101e-04, 3.99949759e-01, -8.66733249e01])
     )
-    
+
+
 class CHIMEExternalBeam(CHIME):
     """Model telescope for the CHIME.
 

--- a/ch_pipeline/core/telescope.py
+++ b/ch_pipeline/core/telescope.py
@@ -196,12 +196,12 @@ class CHIME(telescope.PolarisedTelescope):
     @property
     def fwhm_e(self):
         """Full width half max of the E-plane antenna beam."""
-        return 2.0 * np.pi / 3.0 * 0.7
+        return 1.25 
 
     @property
     def fwhm_h(self):
         """Full width half max of the H-plane antenna beam."""
-        return 2.0 * np.pi / 3.0 * 1.2
+        return 1.25 
 
     # Set the approximate uv feed sizes
     @property

--- a/ch_pipeline/core/telescope.py
+++ b/ch_pipeline/core/telescope.py
@@ -196,12 +196,22 @@ class CHIME(telescope.PolarisedTelescope):
     @property
     def fwhm_e(self):
         """Full width half max of the E-plane antenna beam."""
-        return 1.25 
+        coeff_fwhm_input_Y = np.array([2.41511275e-10,-6.71378830e-07,\
+        7.20183967e-04,-3.52472912e-01,6.73758644e+01])
+        
+        fwhm_freq_Y = np.polyval(coeff_fwhm_input_Y, self.frequencies)
+
+        return fwhm_freq_Y
 
     @property
     def fwhm_h(self):
         """Full width half max of the H-plane antenna beam."""
-        return 1.25 
+        coeff_fwhm_input_X = np.array([ 2.86443038e-10,-7.79063706e-07,\
+        8.15859136e-04,-3.89137634e-01,7.23010129e+01])
+        
+        fwhm_freq_X = np.polyval(coeff_fwhm_input_X, self.frequencies)
+
+        return fwhm_freq_X
 
     # Set the approximate uv feed sizes
     @property
@@ -409,8 +419,8 @@ class CHIME(telescope.PolarisedTelescope):
                 self._angpos,
                 self.zenith,
                 self.cylinder_width / self.wavelengths[freq],
-                self.fwhm_e,
-                self.fwhm_h,
+                self.fwhm_e[freq],
+                self.fwhm_h[freq],
                 rot=rot,
             )
         elif tools.is_array_x(feed_obj):
@@ -418,8 +428,8 @@ class CHIME(telescope.PolarisedTelescope):
                 self._angpos,
                 self.zenith,
                 self.cylinder_width / self.wavelengths[freq],
-                self.fwhm_e,
-                self.fwhm_h,
+                self.fwhm_e[freq],
+                self.fwhm_h[freq],
                 rot=rot,
             )
         else:


### PR DESCRIPTION
Based on FWHM computed from point source model (585-800 MHz), this PR revises north-south FWHM being used in the driftscan beam. Beam measurements point to a lower beam width compared to the existing beam width in driftscan. The discrepancy is larger in X pol. In order to avoid ripples in the beam, FWHM (as a function of frequency) computed for the point source model is fit with a cubic polynomial, and coefficients of the fit are provided to `fwhm_e` and `fwhm_h` functions.

Note that FWHM was optimized only in 585-800 MHz. Using it below that will result in errors due to extrapolation. 

Here is the N-S beam and FWHM comparisons between the two models:

![FWHM_power](https://user-images.githubusercontent.com/19757655/120846464-c68dff80-c537-11eb-8249-cfe1a1ee96e3.png)
![all_models_post_power](https://user-images.githubusercontent.com/19757655/120846468-c7bf2c80-c537-11eb-9841-01229dd9f2cb.png)

Per frequency comparisons are here: https://bao.chimenet.ca/doc/documents/1448
