### PR TITLE
feat(source_removal): reduce memory usage and other improvements

### DIFF
--- a/ch_pipeline/analysis/source_removal.py
+++ b/ch_pipeline/analysis/source_removal.py
@@ -26,7 +26,7 @@ def model_extended_sources(
     distance,
     timestamp,
     bodies,
-    min_altitude=10.0,
+    min_altitude=5.0,
     min_ha=0.0,
     max_ha=0.0,
     **kwargs
@@ -285,7 +285,7 @@ class SolveSources(task.SingleTask):
     extent = config.Property(proptype=list, default=[1.0, 4.0, 4.0, 7.0])
     scale_t = config.Property(proptype=list, default=[0.66, 0.66, 0.66, 0.66])
 
-    min_altitude = config.Property(proptype=float, default=10.0)
+    min_altitude = config.Property(proptype=float, default=5.0)
     max_ha = config.Property(proptype=float, default=0.0)
     min_ha = config.Property(proptype=float, default=0.0)
 
@@ -564,11 +564,11 @@ class LPFSourceAmplitude(task.SingleTask):
         is True.
     """
 
-    window = config.Property(proptype=list, default=[3, 3])
-    niter = config.Property(proptype=list, default=[8, 8])
-    frac_required = config.Property(proptype=float, default=0.80)
+    window = config.Property(proptype=list, default=[3, 5])
+    niter = config.Property(proptype=list, default=[12, 8])
+    frac_required = config.Property(proptype=float, default=0.40)
 
-    ignore_main_lobe = config.Property(proptype=bool, default=False)
+    ignore_main_lobe = config.Property(proptype=bool, default=True)
     main_lobe_threshold = config.Property(proptype=float, default=0.05)
 
     def process(self, model):

--- a/ch_pipeline/analysis/source_removal.py
+++ b/ch_pipeline/analysis/source_removal.py
@@ -1111,7 +1111,7 @@ class SubtractSourcesWithBeam(task.SingleTask):
 
 
 def kz_coeffs(m, k):
-    """Compute the coefficients for a Kolmogorov-Zurbenko filter.
+    """Compute the coefficients for a Kolmogorov-Zurbenko (KZ) filter.
 
     Parameters
     ----------
@@ -1144,7 +1144,15 @@ def kz_coeffs(m, k):
 
 
 def apply_kz_lpf_2d(y, flag, window=3, niter=8, mode="wrap", frac_required=0.80):
-    """Apply a 2D Kolmogorov-Zurbenko filter.
+    """Apply a 2D Kolmogorov-Zurbenko (KZ) filter.
+
+    The KZ filter is an FIR filter that is equivalent to repeated application
+    of a moving average.  The "window" parameter is the size of the moving
+    average window and determines the cut off for the low-pass filter.  The
+    "niter" parameter is the number of times that the moving average is applied
+    and controls the peak-to-sidelobe ratio of the transfer function of the filter.
+    This method pre-computes the coefficients for a given "window" and "niter",
+    and then convolves once with the data.
 
     Parameters
     ----------

--- a/ch_pipeline/analysis/source_removal.py
+++ b/ch_pipeline/analysis/source_removal.py
@@ -539,7 +539,7 @@ class SolveSources(task.SingleTask):
 
 
 class LPFSourceAmplitude(task.SingleTask):
-    """Apply a 2D low-pass filter to the measured source amplitude.
+    """Apply a 2D low-pass filter in (freq, time) to the measured source amplitude.
 
     Attributes
     ----------
@@ -574,7 +574,7 @@ class LPFSourceAmplitude(task.SingleTask):
     main_lobe_threshold = config.Property(proptype=float, default=0.05)
 
     def process(self, model):
-        """Low-pass filter the provided source model.
+        """Low-pass filter the provided source amplitudes.
 
         Parameters
         ----------
@@ -585,7 +585,9 @@ class LPFSourceAmplitude(task.SingleTask):
         -------
         model : containers.SourceModel
             The input container with the amplitude dataset
-            filtered and the weights updated.
+            filtered.  Note that amplitudes that were previously
+            zero will be interpolated to a non-zero value if more than
+            frac_required of the nearby data points are non-zero.
         """
 
         model.redistribute("pol")

--- a/ch_pipeline/core/containers.py
+++ b/ch_pipeline/core/containers.py
@@ -485,14 +485,14 @@ class PointSourceTransit(StaticGainData):
         return self.index_map["param_cov2"]
 
 
-class SourceModel(ContainerBase):
+class SourceModel(FreqContainer):
     """Container for holding model for visiblities.
 
     Model consists of the sum of the signal from
     multiple (possibly extended) sources.
     """
 
-    _axes = ("freq", "pol", "time", "param", "source")
+    _axes = ("pol", "time", "param", "source")
 
     _dataset_spec = {
         "amplitude": {

--- a/ch_pipeline/core/containers.py
+++ b/ch_pipeline/core/containers.py
@@ -498,7 +498,7 @@ class SourceModel(ContainerBase):
         "amplitude": {
             "axes": ["freq", "pol", "time", "source"],
             "dtype": np.complex64,
-            "initialise": True,
+            "initialise": False,
             "distributed": True,
             "distributed_axis": "freq",
         },
@@ -508,12 +508,6 @@ class SourceModel(ContainerBase):
             "initialise": False,
             "distributed": True,
             "distributed_axis": "freq",
-        },
-        "source_index": {
-            "axes": ["param"],
-            "dtype": np.int,
-            "initialise": False,
-            "distributed": False,
         },
     }
 
@@ -526,8 +520,17 @@ class SourceModel(ContainerBase):
         return self.datasets["coeff"]
 
     @property
+    def param(self):
+        return self.index_map["param"]
+
+    @property
+    def source(self):
+        return self.index_map["source"]
+
+    @property
     def source_index(self):
-        return self.datasets["source_index"]
+        src = list(self.source)
+        return np.array([src.index(par) for par in self.param["source"]])
 
 
 class SunTransit(ContainerBase):


### PR DESCRIPTION
- Use new ephemeris methods for computing source positions.

- Add capability to restrict the range of hour angles covered by the source model through the min_ha and max_ha config properties.

- Allow separate masking of N-S and E-W components of the baseline.

- Change data type of the param index map of SourceModel and remove the redundant source_index dataset.

- Move calculation of the source model into the frequency and polarisation loops to reduce memory usage.