### PR TITLE
fix(analysis.fringestop): Pass local array.

### DIFF
--- a/ch_pipeline/analysis/fringestop.py
+++ b/ch_pipeline/analysis/fringestop.py
@@ -73,7 +73,7 @@ class FringeStop(task.SingleTask):
 
         # Fringestop
         fs_vis = tools.fringestop_time(
-            tstream.vis,
+            tstream.vis[:],
             times=tstream.time,
             freq=freq,
             feeds=feeds,


### PR DESCRIPTION
The old way of passing an `MPIarray` no longer works.