### PR TITLE
feat(containers): support HFB archive data

### DIFF
--- a/ch_pipeline/analysis/calibration.py
+++ b/ch_pipeline/analysis/calibration.py
@@ -17,10 +17,10 @@ from ch_util import fluxcat
 from ch_util import finder
 from ch_util import rfi
 
-from draco.core import task
+from draco.core import task, containers
 from draco.util import _fast_tools
 
-from ..core import containers
+from ..core import containers as ccontainers
 from ..core.dataquery import _DEFAULT_NODE_SPOOF
 
 
@@ -1007,7 +1007,7 @@ class TransitFit(task.SingleTask):
 
         Returns
         -------
-        fit : containers.TransitFitParams
+        fit : ccontainers.TransitFitParams
             Parameters of the model fit and their covariance.
         """
         # Ensure that we are distributed over frequency
@@ -1076,7 +1076,7 @@ class TransitFit(task.SingleTask):
         model.fit(ha, vis, err, width=sigma, **self.fit_kwargs)
 
         # Create an output container
-        fit = containers.TransitFitParams(
+        fit = ccontainers.TransitFitParams(
             param=model.parameter_names,
             component=model.component,
             axes_from=response,
@@ -1126,7 +1126,7 @@ class GainFromTransitFit(task.SingleTask):
 
         Parameters
         ----------
-        fit : containers.TransitFitParams
+        fit : ccontainers.TransitFitParams
             Parameters of the model fit and their covariance.
             Must also contain 'model_class' and 'model_kwargs'
             attributes that can be used to evaluate the model.
@@ -1503,7 +1503,7 @@ class SiderealCalibration(task.SingleTask):
             Rigidized sidereal timestream to calibrate.
         inputmap : list of :class:`CorrInput`
             List describing the inputs as they are in the file.
-        inputmask : containers.CorrInputMask
+        inputmask : ccontainers.CorrInputMask
             Mask indicating which correlator inputs to use in the
             eigenvalue decomposition.
 
@@ -1657,7 +1657,7 @@ class SiderealCalibration(task.SingleTask):
                         )
 
             # Create container to hold results of fit
-            gain_data = containers.PointSourceTransit(
+            gain_data = ccontainers.PointSourceTransit(
                 ra=ra_slice, pol_x=xfeeds, pol_y=yfeeds, axes_from=sstream
             )
 

--- a/ch_pipeline/analysis/calibration.py
+++ b/ch_pipeline/analysis/calibration.py
@@ -2201,6 +2201,9 @@ class CalibrationCorrection(task.SingleTask):
                 prod["input_a"][cj],
             )
 
+        # Dereference dataset
+        ssv = sstream.vis[:]
+
         # Loop over flags again
         for flag in self.flags:
 
@@ -2236,7 +2239,7 @@ class CalibrationCorrection(task.SingleTask):
                     )
                     correction[:, do_not_apply, :] = 1.0 + 0.0j
 
-                sstream.vis[:, :, in_range] *= correction
+                ssv.local_array[:, :, in_range] *= correction
 
         # Return input container with phase correction applied
         return sstream

--- a/ch_pipeline/analysis/calibration.py
+++ b/ch_pipeline/analysis/calibration.py
@@ -1,6 +1,9 @@
 """Tasks for calibrating the data."""
 
+from datetime import datetime
 import json
+from typing import List
+from ch_util.andata import CorrData
 
 import numpy as np
 from scipy import interpolate
@@ -16,6 +19,7 @@ from ch_util import cal_utils
 from ch_util import fluxcat
 from ch_util import finder
 from ch_util import rfi
+from ch_util import cal_utils
 
 from draco.core import task, containers
 from draco.util import _fast_tools
@@ -1758,9 +1762,7 @@ class ThermalCalibration(task.SingleTask):
     caltime_path = config.Property(proptype=str)
     node_spoof = config.Property(proptype=dict, default=_DEFAULT_NODE_SPOOF)
 
-    def setup(self):
-        """Load calibration times."""
-        self.caltime_file = memh5.MemGroup.from_hdf5(self.caltime_path)
+    caltime_file = None
 
     def process(self, data):
         """Determine thermal calibration for a sidereal stream or time stream.
@@ -1773,7 +1775,8 @@ class ThermalCalibration(task.SingleTask):
         Returns
         -------
         gain : Either `containers.SiderealGainData` or `containers.GainData`
-            The type depends on the type of `data`.
+            The type depends on the type of `data`. Returns `None` if a thermal
+            correction could not be determined.
 
         """
         # Frequencies and RA/time
@@ -1794,11 +1797,52 @@ class ThermalCalibration(task.SingleTask):
         lo = gain.gain.local_offset[0]
         ls = gain.gain.local_shape[0]
 
-        # Find refference times for each timestamp.
+        # Find reference times for each timestamp.
         # This is the time of the transit from which the gains
         # applied to the data were derived.
-        self.log.info("Getting refference times")
-        reftime_result = self._get_reftime(timestamp, self.caltime_file)
+        self.log.info("Getting reference times")
+
+        reftime_result = None
+
+        # Try and lookup the cal times. Only do this on rank = 0, and then broadcast the
+        # results
+        try:
+            # First attempt to group all dataset_ids for all frequencies on
+            # rank=0 so it can do the full lookup
+            dataset_ids = data.flags["dataset_id"][:].gather(rank=0)
+
+            if self.comm.rank == 0:
+                # Try to use the dataset ID scheme in here, if the time range passed won't
+                # work an exception will be raised...
+                reftime_result = cal_utils.get_reference_times_dataset_id(
+                    timestamp, dataset_ids, logger=self.log
+                )
+
+        # ... catch it and then try to load a calibration time file
+        except (ValueError, KeyError):
+            if self.comm.rank == 0:
+                self.log.debug(
+                    "Could not get cal times via dataset IDs, trying caltime file."
+                )
+
+                if self.caltime_file is None:
+                    self._load_cal_file()
+
+                if timestamp[0] > self._file_start and timestamp[-1] < self._file_end:
+                    reftime_result = cal_utils.get_reference_times_file(
+                        timestamp, self.caltime_file, logger=self.log
+                    )
+                else:
+                    self.log.error("Cal time file does not cover the period requested.")
+
+        reftime_result = self.comm.bcast(reftime_result, root=0)
+
+        if reftime_result is None:
+            self.log.error(
+                "Could not find cal time for incoming data. Check the logs for rank=0 "
+                "to see why."
+            )
+            return None
 
         # Compute gain corrections
         self.log.info("Computing gains corrections")
@@ -1806,9 +1850,14 @@ class ThermalCalibration(task.SingleTask):
 
         # Copy data into container
         gain.gain[:] = g[:]
-        # gain.weight[:] = dr
 
         return gain
+
+    def _load_cal_file(self):
+        """Load the cal time file."""
+        self.caltime_file = memh5.MemGroup.from_hdf5(self.caltime_path)
+        self._file_start = self.caltime_file["tstart"][0]
+        self._file_end = self.caltime_file["tend"][-1]
 
     def _ra2unix(self, csd, ra):
         """csd must be integer"""
@@ -1900,152 +1949,6 @@ class ThermalCalibration(task.SingleTask):
     def _interpolate_temperature(self, temperature_time, temperature_data, times):
         # Interpolate temperatures
         return np.interp(times, temperature_time, temperature_data)
-
-    def _get_reftime(self, times, cal_file):
-        """
-        Parameters
-        ----------
-        times : array of foats
-            Unix time of data points to be calibrated
-        cal_file : memh5.MemGroup object
-            File which containes the reference times
-            for calibration source transits.
-
-        Returns
-        -------
-        reftime : array of floats
-            Unix time of same length as `times'. Reference times of transit of the
-            source used to calibrate the data at each time in `times'. Returns `NaN'
-            for times without a reference.
-        """
-        # Data from calibration file.
-        is_restart = cal_file["is_restart"][:]
-        tref = cal_file["tref"][:]
-        tstart = cal_file["tstart"][:]
-        tend = cal_file["tend"][:]
-        # Length of calibration file and of data points
-        n_cal_file = len(tstart)
-        ntimes = len(times)
-
-        # Len of times, indices in cal_file.
-        last_start_index = np.searchsorted(tstart, times, side="right") - 1
-        # Len of times, indices in cal_file.
-        last_end_index = np.searchsorted(tend, times, side="right") - 1
-        # Check for times before first update or after last update.
-        too_early = last_start_index < 0
-        n_too_early = np.sum(too_early)
-        if n_too_early > 0:
-            msg = (
-                "{0} out of {1} time entries have no reference update."
-                + "Cannot correct gains for those entries."
-            )
-            self.log.warning(msg.format(n_too_early, ntimes))
-        # Fot times after the last update, I cannot be sure the calibration is valid
-        # (could be that the cal file is incomplete. To be conservative, raise warning.)
-        too_late = (last_start_index >= (n_cal_file - 1)) & (
-            last_end_index >= (n_cal_file - 1)
-        )
-        n_too_late = np.sum(too_late)
-        if n_too_late > 0:
-            msg = (
-                "{0} out of {1} time entries are beyond calibration file time values."
-                + "Cannot correct gains for those entries."
-            )
-            self.log.warning(msg.format(n_too_late, ntimes))
-
-        # Array to contain reference times for each entry.
-        # NaN for entries with no reference time.
-        reftime = np.full(ntimes, np.nan, dtype=np.float)
-        # Array to hold reftimes of previous updates
-        # (for entries that need interpolation).
-        reftime_prev = np.full(ntimes, np.nan, dtype=np.float)
-        # Arrays to hold start and stop times of gain transition
-        # (for entries that need interpolation).
-        interp_start = np.full(ntimes, np.nan, dtype=np.float)
-        interp_stop = np.full(ntimes, np.nan, dtype=np.float)
-
-        # Acquisition restart. We load an old gain.
-        acqrestart = is_restart[last_start_index] == 1
-        reftime[acqrestart] = tref[last_start_index][acqrestart]
-
-        # FPGA restart. Data not calibrated.
-        # There shouldn't be any time points here. Raise a warning if there are.
-        fpga_restart = is_restart[last_start_index] == 2
-        n_fpga_restart = np.sum(fpga_restart)
-        if n_fpga_restart > 0:
-            msg = (
-                "{0} out of {1} time entries are after an FPGA restart but before the "
-                + "next kotekan restart. Cannot correct gains for those entries."
-            )
-            self.log.warning(msg.format(n_fpga_restart, ntimes))
-
-        # This is a gain update
-        gainupdate = is_restart[last_start_index] == 0
-
-        # This is the simplest case. Last update was a gain update and
-        # it is finished. No need to interpolate.
-        calrange = (last_start_index == last_end_index) & gainupdate
-        reftime[calrange] = tref[last_start_index][calrange]
-
-        # The next cases might need interpolation. Last update was a gain
-        # update and it is *NOT* finished. Update is in transition.
-        gaintrans = last_start_index == (last_end_index + 1)
-
-        # This update is in gain transition and previous update was an
-        # FPGA restart. Just use new gain, no interpolation.
-        prev_is_fpga = is_restart[last_start_index - 1] == 2
-        prev_is_fpga = prev_is_fpga & gaintrans & gainupdate
-        reftime[prev_is_fpga] = tref[last_start_index][prev_is_fpga]
-
-        # The next two cases need interpolation of gain corrections.
-        # It's not possible to correct interpolated gains because the
-        # products have been stacked. Just interpolate the gain
-        # corrections to avoide a sharp transition.
-
-        # This update is in gain transition and previous update was a
-        # Kotekan restart. Need to interpolate gain corrections.
-        prev_is_kotekan = is_restart[last_start_index - 1] == 1
-        to_interpolate = prev_is_kotekan & gaintrans & gainupdate
-
-        # This update is in gain transition and previous update was a
-        # gain update. Need to interpolate.
-        prev_is_gain = is_restart[last_start_index - 1] == 0
-        to_interpolate = to_interpolate | (prev_is_gain & gaintrans & gainupdate)
-
-        # Reference time of this update
-        reftime[to_interpolate] = tref[last_start_index][to_interpolate]
-        # Reference time of previous update
-        reftime_prev[to_interpolate] = tref[last_start_index - 1][to_interpolate]
-        # Start and stop times of gain transition.
-        interp_start[to_interpolate] = tstart[last_start_index][to_interpolate]
-        interp_stop[to_interpolate] = tend[last_start_index][to_interpolate]
-
-        # For times too early or too late, don't correct gain.
-        # This might mean we don't correct gains right after the last update
-        # that could in principle be corrected. But there is no way to know
-        # If the calibration file is up-to-date and the last update applies
-        # to all entries that come after it.
-        reftime[too_early | too_late] = np.nan
-
-        # Test for un-identified NaNs
-        known_bad_times = (too_early) | (too_late) | (fpga_restart)
-        n_bad_times = np.sum(~np.isfinite(reftime[~known_bad_times]))
-        if n_bad_times > 0:
-            msg = (
-                "{0} out of {1} time entries don't have a reference calibration time "
-                + "without an identifiable cause. Cannot correct gains for those entries."
-            )
-            self.log.warning(msg.format(n_bad_times, ntimes))
-
-        # Bundle result in dictionary
-        result = {
-            "reftime": reftime,
-            "reftime_prev": reftime_prev,
-            "interp_start": interp_start,
-            "interp_stop": interp_stop,
-        }
-
-        return result
 
     def _load_weather(self, time_ranges):
         """Load the chime_weather acquisitions covering the input time ranges."""

--- a/ch_pipeline/analysis/flagging.py
+++ b/ch_pipeline/analysis/flagging.py
@@ -883,7 +883,7 @@ class ApplyCorrInputMask(task.SingleTask):
 
         # Extract input mask and weight array
         weight = timestream.weight[:]
-        mask = cmask.mask[:].view(np.ndarray).astype(weight.dtype)
+        mask = cmask.mask[:].astype(weight.dtype)
 
         # Expand mask to same dimension as weight array
         mask = mask[tuple(slc)]
@@ -1805,7 +1805,7 @@ class DataFlagger(task.SingleTask):
         local_bin = np.array([np.argmin(np.abs(ff - basefreq)) for ff in local_freq])
 
         # Initiate weight mask (1 means not flagged)
-        weight_mask = np.ones((nfreq, ninputs, ntime), dtype=np.bool)
+        weight_mask = np.ones((nfreq, ninputs, ntime), dtype=bool)
 
         # Loop over flags of requested types
         for flag_type, flag_list in self.flags.items():
@@ -1855,7 +1855,7 @@ class DataFlagger(task.SingleTask):
         weight_mask = weight_mask.astype(weight.dtype)
         if stacked:
             # Apply same mask to all products
-            weight *= weight_mask
+            weight.local_array[:] *= weight_mask
         else:
             # Use apply_gain function to apply mask based on product map
             products = timestream.index_map["prod"][

--- a/ch_pipeline/core/containers.py
+++ b/ch_pipeline/core/containers.py
@@ -23,7 +23,8 @@ Tasks
 - :py:class:`MonkeyPatchContainers`
 """
 import posixpath
-from typing import List, Tuple, Union, Any, Optional
+from typing import List, Optional, Union
+from draco.core.task import MPILoggedTask
 
 import numpy as np
 
@@ -1234,21 +1235,39 @@ def make_empty_corrdata(
     return data
 
 
-class MonkeyPatchContainers(pipeline.TaskBase):
+class MonkeyPatchContainers(MPILoggedTask):
     """Patch draco to use CHIME timestream containers.
 
     This task does nothing but perform a monkey patch on `draco.core.containers`
+
+    .. deprecated::
+        This monkey patching scheme is now deprecated. Try to use just use the usual
+        draco infrastructure instead, that is using `draco.core.containers.empty_like`
+        to create a new container and `draco.core.containers.TimeStream` as a generic
+        timestream class and `ch_pipeline.core.containers.CHIMETimeStream` as a slightly
+        more CHIME specific one.
     """
 
     def __init__(self):
+
+        self.log.warning("Deprecated. Try and stop using this monkey patching scheme.")
 
         import ch_pipeline.core.containers as ccontainers
         import draco.core.containers as dcontainers
 
         # Replace the routine for making an empty timestream. This needs to be replaced
         # in both draco and ch_pipeline because of the ways the imports work
-        dcontainers.empty_timestream = ccontainers.make_empty_corrdata
-        ccontainers.empty_timestream = ccontainers.make_empty_corrdata
+
+        def empty_timestream_patch(*args, **kwargs):
+            self.log.warning(
+                "This patching is deprecated. Try using `CHIMETimeStream` instead."
+            )
+            return ccontainers.make_empty_corrdata(*args, **kwargs)
+
+        empty_timestream_patch.__doc__ = ccontainers.make_empty_corrdata.__doc__
+
+        dcontainers.empty_timestream = empty_timestream_patch
+        ccontainers.empty_timestream = empty_timestream_patch
 
         # Save a reference to the original routine
         _make_empty_like = dcontainers.empty_like
@@ -1274,6 +1293,10 @@ class MonkeyPatchContainers(pipeline.TaskBase):
             """
 
             from ch_util import andata
+
+            self.log.warning(
+                "This patching is deprecated. Try using `CHIMETimeStream` instead."
+            )
 
             if isinstance(obj, andata.CorrData):
                 return dcontainers.empty_timestream(

--- a/ch_pipeline/core/containers.py
+++ b/ch_pipeline/core/containers.py
@@ -22,10 +22,13 @@ Tasks
 =====
 - :py:class:`MonkeyPatchContainers`
 """
+import posixpath
+from typing import List, Tuple, Union, Any, Optional
 
 import numpy as np
 
-from caput import memh5, pipeline
+from caput import memh5, pipeline, tod
+from ch_util import andata
 
 from draco.core.containers import *
 
@@ -800,6 +803,216 @@ class Photometry(ContainerBase):
     @property
     def source(self):
         return self.index_map["source"]
+
+
+class RawContainer(TODContainer):
+    """Base class for using raw CHIME data via the draco containers API.
+
+    This modifies the set of allowed group/dataset names to allow access to the
+    flags group.
+    """
+
+    _allowed_groups = ["flags"]
+
+    def group_name_allowed(self, name: str) -> bool:
+        """Allow access to the flags group."""
+
+        # Strip leading and trailing "/"
+        name = name.strip("/")
+
+        return name in self._allowed_groups
+
+    def dataset_name_allowed(self, name: str) -> bool:
+        """Allow access to datasets under both / and /flags."""
+
+        parent_name, name = posixpath.split(name)
+        return parent_name == "/" or self.group_name_allowed(parent_name)
+
+    @classmethod
+    def from_acq_h5(
+        cls,
+        acq_files: Union[str, List[str]],
+        start: Optional[int] = None,
+        stop: Optional[int] = None,
+        **kwargs,
+    ) -> "RawContainer":
+        """Load from an HDF5 file on disk.
+
+        This is a thin wrapper around `from_file` to support the
+        `andata.BaseData.from_acq_h5` API. The main difference is supporting
+        the `start` and `stop` parameters. All other parameters are passed
+        straight into `from_file`.
+
+        .. note:: This does not support loading in a distributed manner as the archive
+            files don't have the correct hints set, but that should be added into this
+            routine by using the information given in the `_dataset_spec` of derived
+            classes.
+
+        Parameters
+        ----------
+        acq_files
+            Path or glob to files (or list of).
+        start, stop
+            Indices into the full set of files to select.
+
+        Returns
+        -------
+        cont
+            A single container instance.
+        """
+
+        if start is None and stop is None:
+            pass
+        elif start is not None and stop is not None:
+            kwargs["time_sel"] = slice(start, stop)
+        else:
+            raise ValueError(
+                f"Got mixed types for start ({type(start)}) and stop ({type(stop)})"
+            )
+
+        return cls.from_file(acq_files, **kwargs)
+
+
+class HFBData(RawContainer, FreqContainer):
+    """A container for HFB data.
+
+    This attempts to wrap the HFB archive format.
+
+    .. note:: This does not yet support distributed loading of HDF5 archive
+       files.
+    """
+
+    _axes = ("subfreq", "beam")
+
+    _dataset_spec = {
+        "hfb": {
+            "axes": ["freq", "subfreq", "beam", "time"],
+            "dtype": np.float32,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
+        "flags/hfb_weight": {
+            "axes": ["freq", "subfreq", "beam", "time"],
+            "dtype": np.float32,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "freq",
+        },
+        "flags/dataset_id": {
+            "axes": ["freq", "time"],
+            "dtype": "U32",
+            "initialise": True,
+            "distributed": False,
+        },
+        "flags/frac_lost": {
+            "axes": ["freq", "time"],
+            "dtype": np.float32,
+            "initialise": False,
+            "distributed": False,
+        },
+    }
+
+    @property
+    def hfb(self) -> memh5.MemDataset:
+        """The main hfb dataset."""
+        return self.datasets["hfb"]
+
+    @property
+    def weight(self) -> memh5.MemDataset:
+        """The inverse variance weight dataset."""
+        return self.datasets["flags/hfb_weight"]
+
+
+class HFBReader(tod.Reader):
+    """A reader for HFB type data."""
+
+    data_class = HFBData
+
+    _freq_sel = None
+
+    @property
+    def freq_sel(self) -> Union[int, list, slice]:
+        """Get the current frequency selection.
+
+        Returns
+        -------
+        freq_sel
+            A frequency selection.
+        """
+
+        return self._freq_sel
+
+    @freq_sel.setter
+    def freq_sel(self, value: Union[int, list, slice]):
+        """Set a frequency selection.
+
+        Parameters
+        ----------
+        value
+            Any type accepted by h5py is valid.
+        """
+        self._freq_sel = andata._ensure_1D_selection(value)
+
+    _beam_sel = None
+
+    @property
+    def beam_sel(self):
+        """Get the current beam selection.
+
+        Returns
+        -------
+        beam_sel
+            The current beam selection.
+        """
+
+        return self._beam_sel
+
+    @beam_sel.setter
+    def beam_sel(self, value):
+        """Set a beam selection.
+
+        Parameters
+        ----------
+        value
+            Any type accepted by h5py is valid.
+        """
+        self._beam_sel = andata._ensure_1D_selection(value)
+
+    def read(self, out_group=None):
+        """Read the selected data.
+
+        Parameters
+        ----------
+        out_group : `h5py.Group`, hdf5 filename or `memh5.Group`
+            Underlying hdf5 like container that will store the data for the
+            BaseData instance.
+
+        Returns
+        -------
+        data : :class:`TOData`
+            Data read from :attr:`~Reader.files` based on the selections made
+            by user.
+
+        """
+        kwargs = {}
+
+        if self._freq_sel is not None:
+            kwargs["freq_sel"] = self._freq_sel
+
+        if self._beam_sel is not None:
+            kwargs["beam_sel"] = self._beam_sel
+
+        kwargs["ondisk"] = False
+
+        return self.data_class.from_mult_files(
+            self.files,
+            data_group=out_group,
+            start=self.time_sel[0],
+            stop=self.time_sel[1],
+            datasets=self.dataset_sel,
+            **kwargs,
+        )
 
 
 def make_empty_corrdata(

--- a/ch_pipeline/core/containers.py
+++ b/ch_pipeline/core/containers.py
@@ -27,10 +27,16 @@ from typing import List, Tuple, Union, Any, Optional
 
 import numpy as np
 
-from caput import memh5, pipeline, tod
+from caput import memh5, tod
 from ch_util import andata
 
-from draco.core.containers import *
+from draco.core.containers import (
+    ContainerBase,
+    StaticGainData,
+    TODContainer,
+    FreqContainer,
+    TimeStream,
+)
 
 
 class RFIMask(ContainerBase):

--- a/ch_pipeline/processing/daily.py
+++ b/ch_pipeline/processing/daily.py
@@ -224,7 +224,7 @@ pipeline:
           stack_ind: 66
 
     # Make a map of the full dataset
-    - type: ch_pipeline.analysis.mapmaker.RingMapMaker
+    - type: draco.analysis.ringmapmaker.RingMapMaker
       requires: manager
       in: sstream_mask
       out: ringmap
@@ -238,7 +238,7 @@ pipeline:
 
     # Make a map from the inter cylinder baselines. This is less sensitive to
     # cross talk and emphasis point sources
-    - type: ch_pipeline.analysis.mapmaker.RingMapMaker
+    - type: draco.analysis.ringmapmaker.RingMapMaker
       requires: manager
       in: sstream_mask
       out: ringmapint


### PR DESCRIPTION
This is a draft implementation of a container type and reader for the HFB data. To run this you'll need to use radiocosmology/caput#198

Things that work:
- Reading HFB files directly using `HFBData.from_file` including axes selections.
- Time, frequency and beam selections via the Reader. Notably the time selections will take a range of UTC times to load.

Things that don't work, or need to be tweaked:
- Compression when saving out containers.
- Distributed reading of data (this requires propagating the distributed parameters from the `_dataset_spec` into the load routines).
- Is this the right place for this code?
- Maybe match the expected Reader API a little better.

This code can be used like the following:
```python
from ch_pipeline.core import containers

fname = "/project/rpp-chime/chime/chime_online/20211022T223938Z_chime_hfb/hfb_00010307_0000.h5"
fnglob = "/project/rpp-chime/chime/chime_online/20211022T223938Z_chime_hfb/hfb_000*.h5"

# Load a single file in ondisk mode (so no data is read immediately)
d = containers.HFBData.from_file(fname, ondisk=True, mode="r")

# Load a range of containers, but don't read any actual datasets (just the ringmaps)
da = containers.HFBData.from_mult_files(fnglob, ondisk=True, mode="r", datasets=())

# Use the reader class to extract a range of time by UTC timestamp and down select on
# both frequency and beam
r = containers.HFBReader(fnglob)
r.select_time_range(1634900000.0, 1634953600.0)
r.freq_sel = slice(4, 10)
r.beam_sel = slice(4, 10)
dr = r.read()
```