### PR TITLE
Ljg/profiling

### DIFF
--- a/ch_pipeline/processing/base.py
+++ b/ch_pipeline/processing/base.py
@@ -389,10 +389,10 @@ def queue_job(script, submit=True, profile=False):
             cmd = "caput-pipeline queue %s"
         else:
             cmd = "caput-pipeline queue --nosubmit %s"
-        
+
         if profile:
             cmd += " --profile"
-            
+
         os.system(cmd % fh.name)
 
 

--- a/ch_pipeline/processing/base.py
+++ b/ch_pipeline/processing/base.py
@@ -336,7 +336,7 @@ class ProcessingType(object):
         # Create instance and set the revision
         return cls(rev[-1])
 
-    def generate(self, max=10, submit=True):
+    def generate(self, max=10, submit=True, profile=False):
         """Queue up jobs that are available to run.
 
         Parameters
@@ -350,7 +350,7 @@ class ProcessingType(object):
         to_run = self.pending()[:max]
 
         for tag in to_run:
-            queue_job(self.job_script(tag), submit=submit)
+            queue_job(self.job_script(tag), submit=submit, profile=profile)
 
     def pending(self):
         """Jobs available to run."""
@@ -375,7 +375,7 @@ def find_venv():
     return os.environ.get("VIRTUAL_ENV", None)
 
 
-def queue_job(script, submit=True):
+def queue_job(script, submit=True, profile=False):
     """Queue a pipeline script given as a string."""
 
     import os
@@ -389,6 +389,10 @@ def queue_job(script, submit=True):
             cmd = "caput-pipeline queue %s"
         else:
             cmd = "caput-pipeline queue --nosubmit %s"
+        
+        if profile:
+            cmd += " --profile"
+            
         os.system(cmd % fh.name)
 
 

--- a/ch_pipeline/processing/client.py
+++ b/ch_pipeline/processing/client.py
@@ -186,6 +186,15 @@ def pending(revision):
     "--submit/--no-submit", default=True, help="Submit the jobs to the queue (or not)"
 )
 @click.option(
+    "--profile",
+    is_flag=True,
+    default=False,
+    help=(
+        "Run the job in a profiler. This will output a `profile_<rank>.prof` file per "
+        "MPI rank if using cProfile or `profile_<rank>.txt` file for pyinstrument,"
+    ),
+)
+@click.option(
     "-f",
     "--fairshare",
     type=float,
@@ -198,7 +207,7 @@ def pending(revision):
     default=None,
     help="Only submit jobs if the user LevelFS is above this threshold.",
 )
-def generate(revision, number, max_number, submit, fairshare, user_fairshare):
+def generate(revision, number, max_number, submit, profile, fairshare, user_fairshare):
     """Submit pending jobs for REVISION (given as type:revision)."""
 
     if fairshare or user_fairshare:
@@ -226,7 +235,7 @@ def generate(revision, number, max_number, submit, fairshare, user_fairshare):
     click.echo(
         f"Generating {number_to_submit} jobs ({number_in_queue} jobs already queued)."
     )
-    revision.generate(max=number_to_submit, submit=submit)
+    revision.generate(max=number_to_submit, submit=submit, profile=profile)
 
 
 def dirstats(path):

--- a/ch_pipeline/processing/client.py
+++ b/ch_pipeline/processing/client.py
@@ -190,8 +190,8 @@ def pending(revision):
     is_flag=True,
     default=False,
     help=(
-        "Run the job in a profiler. This will output a `profile_<rank>.prof` file per "
-        "MPI rank if using cProfile or `profile_<rank>.txt` file for pyinstrument,"
+        "Run the job in cProfile. This will output a `profile_<rank>.prof` file per "
+        "MPI rank."
     ),
 )
 @click.option(

--- a/ch_pipeline/processing/daily.py
+++ b/ch_pipeline/processing/daily.py
@@ -608,7 +608,7 @@ class TestDailyProcessing(DailyProcessing):
             ],
             "freq": [400, 416],
             "product_path": "/project/rpp-krs/chime/bt_empty/chime_4cyl_16freq/",
-            "time": 60,  # How long in minutes?
+            "time": 120,  # How long in minutes?
             "nodes": 1,  # Number of nodes to use.
             "ompnum": 12,  # Number of OpenMP threads
             "pernode": 4,  # Jobs per node


### PR DESCRIPTION
Adds a flag to chp item generate to enable profiling with cProfile. Also doubled the default run time of the test_daily pipeline as the previous default 60 minutes wasn't usually long enough. 