### PR TITLE
fix(dataquery): forcing a list should actually force a list

### DIFF
--- a/ch_pipeline/core/dataquery.py
+++ b/ch_pipeline/core/dataquery.py
@@ -53,7 +53,7 @@ def _force_list(val) -> list:
     """Ensure configuration property is a list."""
     if val is None:
         return []
-    elif hasattr(val, "__iter__"):
+    elif hasattr(val, "__iter__") and not isinstance(val, str):
         return list(val)
     else:
         return [val]

--- a/ch_pipeline/core/dataquery.py
+++ b/ch_pipeline/core/dataquery.py
@@ -49,12 +49,12 @@ from ch_util import tools, ephemeris, finder, layout
 _DEFAULT_NODE_SPOOF = {"cedar_online": "/project/rpp-krs/chime/chime_online/"}
 
 
-def _force_list(val):
+def _force_list(val) -> list:
     """Ensure configuration property is a list."""
     if val is None:
         return []
     elif hasattr(val, "__iter__"):
-        return val
+        return list(val)
     else:
         return [val]
 


### PR DESCRIPTION
Not very important, but function _force_list checks for lists by checking for __iter__ attribute. Tuples, generators, numpy ndarrays, ... all have a __iter__ attribute. Probably will never be an issue, but this change will ensure that the return is actually a list. 