### PR TITLE
fix: check ephemeris sources are present in ch_util.fluxcat 

### DIFF
--- a/ch_pipeline/analysis/sidereal.py
+++ b/ch_pipeline/analysis/sidereal.py
@@ -321,17 +321,17 @@ class SiderealMean(task.SingleTask):
         self.body = []
         if self.mask_sources:
             for src, body in ephemeris.source_dictionary.items():
-                if (
-                    fluxcat.FluxCatalog[src].predict_flux(fluxcat.FREQ_NOMINAL)
-                    > self.flux_threshold
-                ) and (body.dec.degrees > self.dec_threshold):
+                if src in fluxcat.FluxCatalog:
+                    if (
+                        fluxcat.FluxCatalog[src].predict_flux(fluxcat.FREQ_NOMINAL)
+                        > self.flux_threshold
+                    ) and (body.dec.degrees > self.dec_threshold):
 
-                    self.log.info(
-                        "Will mask %s prior to calculating sidereal %s."
-                        % (src, self._name_of_statistic)
-                    )
-
-                    self.body.append(body)
+                        self.log.info(
+                            "Will mask %s prior to calculating sidereal %s."
+                            % (src, self._name_of_statistic)
+                        )
+                        self.body.append(body)
 
     def process(self, sstream):
         """Calculate the mean(median) over the sidereal day.


### PR DESCRIPTION
This will first check,  whether sources present in ephemeris.source_dictionary are also present in ch_util.fluxcat.FluxCatalog. If present then those sources above some flux threshold will be masked prior to estimating the median/mean to remove the cross-talk (noise).  