### PR TITLE
convert ch_pipeline ringmap to draco ringmap container 

### DIFF
--- a/ch_pipeline/analysis/mapmaker.py
+++ b/ch_pipeline/analysis/mapmaker.py
@@ -68,6 +68,11 @@ class RingMapMaker(task.SingleTask):
         tel : TransitTelescope
         """
 
+        self.log.warning(
+            "This task is deprecated.  Please use "
+            "draco.analysis.ringmapmaker.RingMapMaker instead."
+        )
+
         if self.weight not in ["natural", "uniform", "inverse_variance"]:
             KeyError("Do not recognize weight = %s" % self.weight)
 

--- a/ch_pipeline/analysis/mapmaker.py
+++ b/ch_pipeline/analysis/mapmaker.py
@@ -60,8 +60,8 @@ class ConvertRingmap(task.SingleTask):
             rmap_out.dirty_beam[:] = rmap_in.dirty_beam[:]
 
         return rmap_out
-    
-    
+
+
 class RingMapMaker(task.SingleTask):
     """A simple and quick map-maker that forms a series of beams on the meridian.
 

--- a/ch_pipeline/analysis/mapmaker.py
+++ b/ch_pipeline/analysis/mapmaker.py
@@ -17,51 +17,6 @@ from ch_util import ephemeris
 from ..core import containers
 
 
-class ConvertRingmap(task.SingleTask):
-    """Covert a ch_pipeline RingMap to a draco RingMap.
-
-    The ch_pipeline RingMap container has an rms dataset instead of
-    a weight dataset. This task converts rms to weight and stores the
-    result in a draco RingMap container.
-    """
-
-    def process(self, rmap_in):
-        """Convert a ch_pipline RingMap to a draco RingMap.
-
-        Parameters
-        ----------
-        rmap_in : ch_pipeline.core.containers.RingMap
-            input map to convert
-
-        Returns
-        -------
-        rmap_out : draco.core.containers.RingMap
-            converted ringmap.
-        """
-
-        from draco.core.containers import RingMap
-
-        rmap_in.redistribute("freq")
-
-        rmap_out = RingMap(
-            axes_from=rmap_in,
-            attrs_from=rmap_in,
-            distributed=rmap_in.distributed,
-            comm=rmap_in.comm,
-        )
-
-        rmap_out.redistribute("freq")
-
-        rmap_out.map[:] = rmap_in.map[:]
-        rmap_out.weight[:] = tools.invert_no_zero(rmap_in.rms[:][..., np.newaxis] ** 2)
-
-        if "dirty_beam" in rmap_in.datasets:
-            rmap_out.add_dataset("dirty_beam")
-            rmap_out.dirty_beam[:] = rmap_in.dirty_beam[:]
-
-        return rmap_out
-
-
 class RingMapMaker(task.SingleTask):
     """A simple and quick map-maker that forms a series of beams on the meridian.
 
@@ -306,3 +261,48 @@ class RingMapMaker(task.SingleTask):
             )
 
         return rm
+
+
+class ConvertRingMap(task.SingleTask):
+    """Covert a ch_pipeline RingMap to a draco RingMap.
+
+    The ch_pipeline RingMap container has an rms dataset instead of
+    a weight dataset. This task converts rms to weight and stores the
+    result in a draco RingMap container.
+    """
+
+    def process(self, rmap_in):
+        """Convert a ch_pipline RingMap to a draco RingMap.
+
+        Parameters
+        ----------
+        rmap_in : ch_pipeline.core.containers.RingMap
+            input map to convert
+
+        Returns
+        -------
+        rmap_out : draco.core.containers.RingMap
+            converted ringmap.
+        """
+
+        from draco.core.containers import RingMap
+
+        rmap_in.redistribute("freq")
+
+        rmap_out = RingMap(
+            axes_from=rmap_in,
+            attrs_from=rmap_in,
+            distributed=rmap_in.distributed,
+            comm=rmap_in.comm,
+        )
+
+        rmap_out.redistribute("freq")
+
+        rmap_out.map[:] = rmap_in.map[:]
+        rmap_out.weight[:] = tools.invert_no_zero(rmap_in.rms[:][..., np.newaxis] ** 2)
+
+        if "dirty_beam" in rmap_in.datasets:
+            rmap_out.add_dataset("dirty_beam")
+            rmap_out.dirty_beam[:] = rmap_in.dirty_beam[:]
+
+        return rmap_out

--- a/ch_pipeline/analysis/mapmaker.py
+++ b/ch_pipeline/analysis/mapmaker.py
@@ -18,8 +18,8 @@ from ..core import containers
 
 
 class ConvertRingmap(task.SingleTask):
-    """ Covert a ch_pipeline RingMap to a draco RingMap.
-    
+    """Covert a ch_pipeline RingMap to a draco RingMap.
+
     The ch_pipeline RingMap container has an rms dataset instead of
     a weight dataset. This task converts rms to weight and stores the
     result in a draco RingMap container.
@@ -40,6 +40,7 @@ class ConvertRingmap(task.SingleTask):
         """
 
         from draco.core.containers import RingMap
+
         rmap_in.redistribute("freq")
 
         rmap_out = RingMap(


### PR DESCRIPTION
Covert the daily ch_pipeline ringmap to draco ringmap. The daily ringmap of ch_pipeline has rms axis instead of weight, so we are changing rms to weight and storing it in a new draco ringmap container.