### PR TITLE
feat(io): Load HFB data with selections

### DIFF
--- a/ch_pipeline/core/io.py
+++ b/ch_pipeline/core/io.py
@@ -273,10 +273,10 @@ class LoadDataFiles(task.SingleTask):
         rd.select_time_range(time_range[0], time_range[1])
 
         # Select frequency range
-        rd.freq_sel(self.freq_sel)
+        rd.freq_sel = self.freq_sel
 
         # Select beams
-        rd.beam_sel(self.beam_sel)
+        rd.beam_sel = self.beam_sel
 
         self.log.info(f"Reading file {self._file_ptr} of {len(self.files)}. ({file_})")
         ts = rd.read()

--- a/ch_pipeline/core/io.py
+++ b/ch_pipeline/core/io.py
@@ -222,6 +222,9 @@ class LoadDataFiles(task.SingleTask):
         "hfb": containers.HFBReader,
     }
 
+    freq_sel = config.Property(default=None)
+    beam_sel = config.Property(default=None)
+
     def setup(self, files):
         """Set the list of files to load.
 
@@ -269,8 +272,11 @@ class LoadDataFiles(task.SingleTask):
         # Select time range
         rd.select_time_range(time_range[0], time_range[1])
 
-        # config parameters: select freq range, beam
-        # support freq, beam selection
+        # Select frequency range
+        rd.freq_sel(self.freq_sel)
+
+        # Select beams
+        rd.beam_sel(self.beam_sel)
 
         self.log.info(f"Reading file {self._file_ptr} of {len(self.files)}. ({file_})")
         ts = rd.read()

--- a/ch_pipeline/core/io.py
+++ b/ch_pipeline/core/io.py
@@ -219,6 +219,7 @@ class LoadDataFiles(task.SingleTask):
         "gain": andata.CalibrationGainReader,
         "digitalgain": andata.DigitalGainReader,
         "flaginput": andata.FlagInputReader,
+        "hfb": containers.HFBReader,
     }
 
     def setup(self, files):
@@ -255,8 +256,21 @@ class LoadDataFiles(task.SingleTask):
         file_ = self.files[self._file_ptr]
         self._file_ptr += 1
 
+        # Handle file lists including time ranges
+        if isinstance(file_, tuple):
+            time_range = file_[1]
+            file_ = file_[0]
+        else:
+            time_range = (None, None)
+
         # Set up a Reader class
         rd = self._acqtype_reader[self.acqtype](file_)
+
+        # Select time range
+        rd.select_time_range(time_range[0], time_range[1])
+
+        # config parameters: select freq range, beam
+        # support freq, beam selection
 
         self.log.info(f"Reading file {self._file_ptr} of {len(self.files)}. ({file_})")
         ts = rd.read()


### PR DESCRIPTION
This is ready for review.

Changes `core.io.LoadDataFiles` to load HFB data.

Selections in e.g. beam number or frequency index can be achieved as documented in `draco.core.io.BaseLoadFiles`.