### PR TITLE
feat(flagging): create task for masking decorrelated cylinders

### DIFF
--- a/ch_pipeline/analysis/flagging.py
+++ b/ch_pipeline/analysis/flagging.py
@@ -1738,8 +1738,8 @@ class MaskDecorrelatedCylinder(task.SingleTask):
     def process(self, data, inputmap):
         """Create the mask.
 
-        Parmeters
-        ---------
+        Parameters
+        ----------
         data : TimeStream
             Visibilites before averaging over cylinders.
         inputmap : list of :class:`CorrInput`

--- a/ch_pipeline/analysis/flagging.py
+++ b/ch_pipeline/analysis/flagging.py
@@ -1793,7 +1793,7 @@ class MaskDecorrelatedCylinder(task.SingleTask):
         prodstack["input_a"] = np.where(conj, t["input_b"], t["input_a"])
         prodstack["input_b"] = np.where(conj, t["input_a"], t["input_b"])
 
-        # Calculate baseline distance, polarisation pair, cylinder pair
+        # Calculate baseline distance and polarisation pair
         index_a = prodstack["input_a"]
         index_b = prodstack["input_b"]
 
@@ -1818,7 +1818,7 @@ class MaskDecorrelatedCylinder(task.SingleTask):
 
         isort = np.argsort(index)
 
-        # Determine boundaries of unique pol/baselines.
+        # Determine boundaries of unique pol/baselines
         bnd = np.concatenate(
             ([0], np.flatnonzero(np.diff(index[isort]) > 0) + 1, [index.size])
         )
@@ -1856,7 +1856,7 @@ class MaskDecorrelatedCylinder(task.SingleTask):
         flag = (data.weight[:].local_array[:] > 0.0)[:, pindex, :]
 
         # Define slices that will expand both the coefficients and data
-        # to the correct shape for broadcasting against each other.
+        # to the correct shape for broadcasting against each other
         cslc = (slice(None), slice(None), slice(None), None)
         dslc = (None, slice(None), slice(None), slice(None))
 

--- a/ch_pipeline/analysis/flagging.py
+++ b/ch_pipeline/analysis/flagging.py
@@ -1702,6 +1702,348 @@ class MaskCHIMEMisc(task.SingleTask):
         return ss
 
 
+class MaskDecorrelatedCylinder(task.SingleTask):
+    """Identify and mask frequencies and times where a cylinder decorrelated.
+
+    Parameters
+    ----------
+    threshold: int
+        Mask frequencies and times where the median ratio of the
+        average-without-cylinder to average-with-cylinder visibility
+        amplitude is greater than this threshold.
+    max_frac_freq: float
+        Mask any frequency that was transmitted by an FPGA motherboard slot
+        with more than this fraction of frequencies masked by the above
+        threshold.  Only relevant if the frequency map is provided at setup.
+    """
+
+    threshold = config.Property(proptype=float, default=5.0)
+    max_frac_freq = config.Property(proptype=float, default=0.1)
+
+    def setup(self, freq_map=None):
+        """Determine the frequencies handled by each FPGA motherboard slot.
+
+        If a motherboard decorrelates, then all frequencies transmitted by
+        that slot will be affected.
+
+        Parameters
+        ----------
+        freq_map : FrequencyMap
+            The mapping between frequency bin and [crate, slot, link]
+            as a function of time.
+        """
+
+        self._set_slot_freqs(freq_map)
+
+    def process(self, data, inputmap):
+        """Create the mask.
+
+        Parmeters
+        ---------
+        data : TimeStream
+            Visibilites before averaging over cylinders.
+        inputmap : list of :class:`CorrInput`
+            A list describing the inputs in data.
+
+        Returns
+        -------
+        out : RFIMask
+            Mask with True indicating that a cylinder decorrelated
+            at that frequency and time.
+        """
+
+        from draco.analysis.ringmapmaker import find_grid_indices
+
+        # Distribute over frequencies
+        data.redistribute("freq")
+
+        # Get polarisations of feeds
+        pol = tools.get_feed_polarisations(inputmap)
+
+        # Get positions of feeds
+        pos = tools.get_feed_positions(inputmap)
+
+        # Get cylinder each feed is on
+        cyl = np.array(
+            [chr(63 + inp.cyl) if tools.is_chime(inp) else "0" for inp in inputmap]
+        )
+        ucyl = np.unique(cyl[cyl != "0"])
+        ncyl = ucyl.size
+
+        # Make sure that none of our typical products reference non-array feeds
+        stack_new, stack_flag = tools.redefine_stack_index_map(
+            inputmap, data.prod, data.stack, data.reverse_map["stack"]
+        )
+
+        valid_stack = np.flatnonzero(stack_flag)
+        ninvalid = stack_new.size - valid_stack.size
+
+        if ninvalid > 0:
+            stack_new = stack_new[valid_stack]
+            self.log.info(
+                "Could not find appropriate reference inputs for "
+                f"{ninvalid:0.0f} stacked products.  Ignoring these "
+                "products in decorrelated cylinder calculation."
+            )
+
+        t = data.prod[stack_new["prod"]]
+
+        prodstack = t.copy()
+        conj = stack_new["conjugate"]
+        prodstack["input_a"] = np.where(conj, t["input_b"], t["input_a"])
+        prodstack["input_b"] = np.where(conj, t["input_a"], t["input_b"])
+
+        # Calculate baseline distance, polarisation pair, cylinder pair
+        index_a = prodstack["input_a"]
+        index_b = prodstack["input_b"]
+
+        bdist = pos[index_a] - pos[index_b]
+        bpol = np.core.defchararray.add(pol[index_a], pol[index_b])
+
+        # Find the grid indices
+        xind, yind, dx, dy = find_grid_indices(bdist)
+
+        # Only use the co-polar, 1-cylinder separation visibilities for this analysis
+        ico = np.flatnonzero((pol[index_a] == pol[index_b]) & (np.abs(xind) == 1))
+
+        # Create an identifier based on the polarisation pair and north-south baseline
+        pol_map = {pstr: pp for pp, pstr in enumerate(np.unique(bpol[ico]))}
+
+        idd = np.zeros((ico.size, 2), dtype=int)
+        idd[:, 0] = [pol_map[bpol[ii]] for ii in ico]
+        idd[:, 1] = yind[ico]
+
+        # Find the unique pol/baselines and the inverse map
+        uidd, index = np.unique(idd, return_inverse=True, axis=0)
+
+        isort = np.argsort(index)
+
+        # Determine boundaries of unique pol/baselines.
+        bnd = np.concatenate(
+            ([0], np.flatnonzero(np.diff(index[isort]) > 0) + 1, [index.size])
+        )
+
+        # Ignore any unique pol/baseline that does not have ncyl - 1 redundant copies.
+        # This can happen due to the valid_stack selection.
+        ncopies = bnd[1:] - bnd[:-1]
+        bflag = ncopies == (ncyl - 1)
+        nmeas = np.sum(bflag)
+
+        # Loop over the unique pol/baselines and for each one determine if each of the
+        # cylinders is present in each of the redundant copies
+        pindex = np.zeros((nmeas, ncyl - 1), dtype=int)
+        flag_with = np.zeros((ncyl, nmeas, ncyl - 1), dtype=bool)
+
+        cc = 0
+        for bb in range(nmeas):
+
+            if not bflag[bb]:
+                continue
+
+            pi = ico[isort[bnd[bb] : bnd[bb + 1]]]
+            pindex[cc] = valid_stack[pi]
+
+            flag_with[:, cc, :] = np.char.equal(
+                ucyl[:, np.newaxis], cyl[index_a[pi]][np.newaxis, :]
+            ) | np.char.equal(ucyl[:, np.newaxis], cyl[index_b[pi]][np.newaxis, :])
+
+            cc += 1
+
+        flag_without = ~flag_with
+
+        # Extract the required data products
+        vis = data.vis[:].local_array[:, pindex, :]
+        flag = (data.weight[:].local_array[:] > 0.0)[:, pindex, :]
+
+        # Define slices that will expand both the coefficients and data
+        # to the correct shape for broadcasting against each other.
+        cslc = (slice(None), slice(None), slice(None), None)
+        dslc = (None, slice(None), slice(None), slice(None))
+
+        # Create an array to fill with the final mask
+        mask = np.zeros((vis.shape[0], vis.shape[-1]), dtype=bool)
+
+        # Loop over frequencies
+        for ff in range(vis.shape[0]):
+
+            # For each cylinder, average the magnitude of the visibilities for:
+            #   all redundant baselines that contain that cylinder
+            #   all redundant baselines that do not contain that cylinder
+            fwith = flag_with[cslc] * flag[ff][dslc]
+            fwithout = flag_without[cslc] * flag[ff][dslc]
+
+            norm_with = np.sum(fwith, axis=2).astype(np.float32)
+            norm_without = np.sum(fwithout, axis=2).astype(np.float32)
+
+            avg_with = np.sum(
+                fwith * np.abs(vis[ff][dslc]), axis=2
+            ) * tools.invert_no_zero(norm_with)
+            avg_without = np.sum(
+                fwithout * np.abs(vis[ff][dslc]), axis=2
+            ) * tools.invert_no_zero(norm_without)
+
+            # Take the ratio of without the cylinder to with the cylinder
+            ratio = avg_without * tools.invert_no_zero(avg_with)
+
+            valid = (norm_with > 0.0) & (norm_without > 0.0)
+
+            # Take the median of the ratio over all unique baselines
+            med = np.nanmedian(np.where(valid, ratio, np.nan), axis=1)
+
+            # Mask any time where the median was greater than some threshold
+            mask[ff] = np.any(med > self.threshold, axis=0)
+
+        # Gather the mask for all frequencies on all nodes
+        mask = mpiarray.MPIArray.wrap(mask, axis=0).allgather()
+
+        # If more than some (user specified) fraction of frequencies transmitted
+        # by an FPGA motherboard slot have been masked, then mask all frequencies
+        # transmitted by that motherboard slot.  The cylinder decorrelation is
+        # expected to affect all of these frequencies.  This step is only possible
+        # if the frequency map as a function of time has been provided on setup.
+        if self.freq_map is not None:
+
+            grouper, slot_index = self._get_slot_freqs(data.time[0])
+
+            frac_freq_masked = np.sum(mask[grouper, :], axis=1) / grouper.shape[1]
+
+            mask = mask | (frac_freq_masked > self.max_frac_freq)[slot_index, :]
+
+        # Print the fraction of data that has been masked by this task
+        self.log.info(
+            "%0.2f percent of data was masked due to a decorrelated cylinder."
+            % (100.0 * np.sum(mask) / np.prod(mask.shape),)
+        )
+
+        # Create output container and store final mask
+        out = dcontainers.RFIMask(axes_from=data, attrs_from=data)
+
+        out.mask[:] = mask
+
+        return out
+
+    def _set_slot_freqs(self, freq_map):
+        """Determine the slot to frequency map as a function of time.
+
+        Parameters
+        ----------
+        freq_map : FrequencyMap
+            The mapping between frequency bin and [crate, slot, link]
+            as a function of time.
+        """
+
+        if freq_map is not None:
+
+            islot = list(freq_map.level).index("slot")
+            slot = freq_map.stream[:, :, islot]
+
+            nslot = np.max(slot) + 1
+            ntime, nfreq = slot.shape
+            nfreq_per_slot = nfreq // nslot
+
+            grouper = np.zeros((ntime, nslot, nfreq_per_slot), dtype=int)
+            for tt in range(ntime):
+                grouper[tt] = np.argsort(slot[tt], kind="mergesort").reshape(
+                    nslot, nfreq_per_slot
+                )
+
+            self.freq_map = freq_map
+            self.grouper = grouper
+            self.slot_index = slot
+
+        else:
+
+            self.freq_map = None
+
+    def _get_slot_freqs(self, timestamp):
+        """Look up the slot to frequency map that was used at a given time.
+
+        Parameters
+        ----------
+        timestamp : float64
+            Unix timestamp.
+
+        Returns
+        -------
+        grouper : np.ndarray[nslot, nfreq_per_slot]
+            Index into the frequency axis that will group
+            frequency channels based on the FPGA motherboard slot
+            that transmitted them.
+        slot_index : np.ndarray[nfreq,]
+            Index into the slot axis that will yield the
+            FPGA motherboard slot that transmitted each
+            frequency channel.
+        """
+
+        tindex = np.digitize(timestamp, self.freq_map.time) - 1
+
+        if tindex < 0:
+            tbefore = (self.freq_map.time.min() - timestamp) / (24 * 3600)
+            raise RuntimeError(
+                "Requested timestamp is before the earliest time "
+                f"in the frequency map file by {tbefore:0.1f} days."
+            )
+
+        if timestamp > self.freq_map.attrs["end_time"]:
+            tafter = (timestamp - self.freq_map.attrs["end_time"]) / (24 * 3600)
+            self.log.warning(
+                "Requested timestamp is after the end time covered "
+                f"by the frequency map file by {tafter:0.1f} days.  "
+                "Please ensure that the frequency map has not been "
+                "updated since then."
+            )
+
+        return self.grouper[tindex], self.slot_index[tindex]
+
+
+class ExpandMask(task.SingleTask):
+    """Expand a mask along the time/RA axis.
+
+    Used to mask the transitional regions between good and bad data.
+
+    Parameters
+    ----------
+    nexpand : int
+        If a time/RA is within nexpand samples from a masked time/RA,
+        then it will be masked in the output.
+    in_place : bool
+        If True, then overwrite the raw mask with the expanded mask.
+        If False, then create a new container with the expanded mask.
+    """
+
+    nexpand = config.Property(proptype=int, default=1)
+    in_place = config.Property(proptype=bool, default=False)
+
+    def process(self, raw_mask):
+        """Mask any times/RAs that neighbor a masked time/RA.
+
+        Parameters
+        ----------
+        raw_mask : RFIMask or SiderealRFIMask
+
+        Returns
+        -------
+        exp_mask : RFIMask or SiderealRFIMask
+        """
+
+        nfreq, ntime = raw_mask.mask[:].shape
+
+        mraw = np.zeros((nfreq, ntime + 2 * self.nexpand), dtype=bool)
+        mraw[:, self.nexpand : -self.nexpand] = raw_mask.mask[:]
+
+        window = 2 * self.nexpand + 1
+        mexp = np.any(rfi._rolling_window_lastaxis(mraw, window), axis=-1)
+
+        if self.in_place:
+            exp_mask = raw_mask
+        else:
+            exp_mask = dcontainers.empty_like(raw_mask)
+
+        exp_mask.mask[:] = mexp
+
+        return exp_mask
+
+
 class DataFlagger(task.SingleTask):
     """Flag data based on DataFlags in database.
 

--- a/ch_pipeline/core/containers.py
+++ b/ch_pipeline/core/containers.py
@@ -6,6 +6,7 @@ containers which are imported into this module.
 
 Containers
 ==========
+- :py:class:`FrequencyMap`
 - :py:class:`RFIMask`
 - :py:class:`CorrInputMask`
 - :py:class:`CorrInputTest`
@@ -38,6 +39,39 @@ from draco.core.containers import (
     FreqContainer,
     TimeStream,
 )
+
+
+class FrequencyMap(FreqContainer, TODContainer):
+    """Map between frequency bin and FPGA stream (GPU node) as a function of time."""
+
+    _axes = ("level",)
+
+    _dataset_spec = {
+        "stream": {
+            "axes": ["time", "freq", "level"],
+            "dtype": int,
+            "initialise": True,
+            "distributed": False,
+        },
+        "node": {
+            "axes": ["time", "freq"],
+            "dtype": "<U5",
+            "initialise": True,
+            "distributed": False,
+        },
+    }
+
+    @property
+    def level(self):
+        return self.index_map["level"]
+
+    @property
+    def stream(self):
+        return self.datasets["stream"]
+
+    @property
+    def node(self):
+        return self.datasets["node"]
 
 
 class RFIMask(ContainerBase):

--- a/examples/test_decorr_cyl.yaml
+++ b/examples/test_decorr_cyl.yaml
@@ -1,0 +1,108 @@
+# Example of a config file that runs the MaskDecorrelatedCylinder task.
+# Processed 4 chimestack files from March 2020 where a decorrelated cylinder
+# is known to have occured.  Outputs an RFIMask that can be applied to the
+# visibility data.
+cluster:
+    directory:          $SCRATCH/decorrelated_cylinder/202003/
+    venv:               my_venv
+
+    ## Cluster configuration (ignored unless on a cluster)
+    name:               decorr_cyl              # Jobname
+    nodes:              4                       # Number of nodes to run on
+    time:               30                      # Time to run for (in minutes)
+    ompnum:             1                       # Number of OpenMP threads
+    pernode:            32
+    mem:                128000M
+    system:            'cedar'
+    account:           'rpp-krs'
+
+# Pipeline task configuration
+pipeline:
+
+  logging:
+    root: DEBUG
+    peewee: INFO
+    matplotlib: INFO
+
+  save_versions:
+    - caput
+    - ch_util
+    - ch_pipeline
+    - chimedb.core
+    - chimedb.data_index
+    - chimedb.dataflag
+    - cora
+    - draco
+    - drift
+    - numpy
+    - scipy
+    - h5py
+    - mpi4py
+
+  tasks:
+
+    - type: draco.core.task.SetMPILogging
+      params:
+        level_rank0: INFO
+        level_all: ERROR
+
+    # Load product manager for sidereal grouping
+    - type: draco.core.io.LoadProductManager
+      out: manager
+      params:
+        product_directory: "/project/rpp-krs/chime/beam_transfers/chime_4cyl_585-800_I_XX-YY_psbeam"
+
+    # Load the frequency map
+    - type: ch_pipeline.core.io.LoadSetupFile
+      out: freqmap
+      params:
+          filename: "/project/rpp-chime/chime/chime_processed/freq_map/20180902_20220927_freq_map.h5"
+          distributed: false
+
+    # Load files where a decorrelation occured
+    - type: draco.core.io.FindFiles
+      out: filelist
+      params:
+          files:  ['/project/rpp-krs/chime/chime_online/20200319T203535Z_chimestack_corr/00244307_0000.h5',
+                   '/project/rpp-krs/chime/chime_online/20200319T203535Z_chimestack_corr/00249397_0000.h5',
+                   '/project/rpp-krs/chime/chime_online/20200319T203535Z_chimestack_corr/00254486_0000.h5',
+                   '/project/rpp-krs/chime/chime_online/20200319T203535Z_chimestack_corr/00341008_0000.h5']
+
+    - type: ch_pipeline.core.io.LoadCorrDataFiles
+      requires: filelist
+      out: tstream
+
+     # Get the telescope layout that was active when this data file was recorded
+    - type: ch_pipeline.core.dataquery.QueryInputs
+      in: tstream
+      out: inputmap
+      params:
+          cache: true
+
+     # Generate mask
+    - type: ch_pipeline.analysis.flagging.MaskDecorrelatedCylinder
+      requires: freqmap
+      in: [tstream, inputmap]
+      out: mask
+      params:
+          threshold: 5.0
+          max_frac_freq: 0.1
+
+    # Concatenate together all the masks
+    - type: draco.analysis.sidereal.SiderealGrouper
+      requires: manager
+      in: mask
+      out: mask_day
+      params:
+          save: true
+          output_name: "decorrelated_cylinder_mask_{tag}.h5"
+
+    # Expand the mask along the time axis
+    - type: ch_pipeline.analysis.flagging.ExpandMask
+      in: mask_day
+      out: mask_day_exp
+      params:
+          nexpand: 6
+          in_place: true
+          save: true
+          output_name: "decorrelated_cylinder_mask_expanded_{tag}.h5"


### PR DESCRIPTION
Creates a `MaskDecorrelatedCylinder` task that can be run in the daily pipeline prior to averaging over cylinder pair to identify decorrelated cylinders.  Outputs an RFIMask that when applied to the visibility data will mask any time and frequency where a decorrelated cylinder occured.

Provides [examples/test_decorr_cyl.yaml](https://github.com/chime-experiment/ch_pipeline/compare/ss/decorrelated_cyl?expand=1#diff-bb39f099ab51a8c4870537d5a946aa5820eb9403e5c1dc0f991618b8d60d8e1c) as an example of how to run the task.

The identification is more effective if the task is provided the map between frequency bin and FPGA motherboard slot.  I have generated this map for all past data based on the `fpga-master` configuration files and saved it to `/project/rpp-chime/chime/chime_processed/freq_map/20180902_20220927_freq_map.h5`.  This file would need to be appended to whenever the frequency remapping is updated in the real-time pipeline.  Ideally there would be a way to get the map automatically.