### PR TITLE
feat(client): option to select user when getting slurm jobs

### DIFF
--- a/ch_pipeline/processing/base.py
+++ b/ch_pipeline/processing/base.py
@@ -220,7 +220,7 @@ class ProcessingType(object):
 
         return cls(new_rev, create=True)
 
-    def queued(self):
+    def queued(self, user=None):
         """Get the queued and running jobs of this type.
 
         Returns
@@ -234,7 +234,7 @@ class ProcessingType(object):
         job_regex = re.compile("^%s$" % self.job_name(self.tag_pattern))
 
         # Find matching jobs
-        jobs = [job for job in slurm_jobs() if job_regex.match(job["NAME"])]
+        jobs = [job for job in slurm_jobs(user=user) if job_regex.match(job["NAME"])]
 
         running = [job["NAME"].split("/")[-1] for job in jobs if job["ST"] == "R"]
         waiting = [job["NAME"].split("/")[-1] for job in jobs if job["ST"] == "PD"]
@@ -353,16 +353,16 @@ class ProcessingType(object):
         for tag in to_run:
             queue_job(self.job_script(tag), submit=submit)
 
-    def pending(self):
+    def pending(self, user=None):
         """Jobs available to run."""
 
-        waiting, running = self.queued()
+        waiting, running = self.queued(user)
         not_pending = set(self.ls()) | set(waiting) | set(running)
         pending = [job for job in self.available() if job not in not_pending]
 
         return pending
 
-    def crashed(self) -> list:
+    def crashed(self, user=None) -> list:
         """Find all jobs which have crashed.
 
         Returns
@@ -385,7 +385,7 @@ class ProcessingType(object):
         }
         # Get finished, waiting, and running jobs
         finished_tags = self.ls()
-        waiting_tags, running_tags = self.queued()
+        waiting_tags, running_tags = self.queued(user)
         # Any tag in the working directory that is not running or
         # waiting should be considered as crashed. Also consider
         # finished tags to catch edge case where a tag is in the

--- a/ch_pipeline/processing/client.py
+++ b/ch_pipeline/processing/client.py
@@ -231,14 +231,21 @@ def generate(revision, number, max_number, submit, fairshare, user_fairshare):
 
 @item.command("metrics")
 @click.argument("revision", type=PREV)
-def metrics_list(revision):
+@click.option(
+    "-u",
+    "--user",
+    type=str,
+    default=None,
+    help="User to check jobs for.",
+)
+def metrics_list(revision, user):
     """Show metrics about currently running jobs for
     REVISION (given as (type:revision)."""
 
     fs = base.slurm_fairshare("rpp-chime_cpu")
     complete = revision.ls()
     available = revision.available()
-    waiting, running = revision.queued()
+    waiting, running = revision.queued(user)
     failed = revision.crashed()
     # Direct copy from revision.pending method, put here
     # to avoid duplicate calls

--- a/ch_pipeline/processing/client.py
+++ b/ch_pipeline/processing/client.py
@@ -235,7 +235,7 @@ def generate(revision, number, max_number, submit, fairshare, user_fairshare):
     "-u",
     "--user",
     type=str,
-    default=None,
+    default="chime",
     help="User to check jobs for.",
 )
 def metrics_list(revision, user):


### PR DESCRIPTION
`chp` commands for checking pending and running jobs would only get jobs being run by the current user. Jobs being run by a special account, such as the chime account (which is used for daily pipeline jobs) are visible to all users but could not be fetched by `chp` commands. This change adds a user option when finding slurm jobs, and adds a `-u` option when calling `chp metrics`. This also fixes #126 