### PR TITLE
feat(base): method to get all job tag status items.

### DIFF
--- a/ch_pipeline/processing/client.py
+++ b/ch_pipeline/processing/client.py
@@ -243,22 +243,11 @@ def metrics_list(revision, user):
     REVISION (given as (type:revision)."""
 
     fs = base.slurm_fairshare("rpp-chime_cpu")
-    complete = revision.ls()
-    available = revision.available()
-    waiting, running = revision.queued(user)
-    failed = revision.crashed(user)
-    # Direct copy from revision.pending method, put here
-    # to avoid duplicate calls
-    not_pending = set(complete) | set(waiting) | set(running)
-    pending = [job for job in available if job not in not_pending]
+    tag_status = revision.status(user)
 
     click.echo(f"Fairshare: {fs[0]}")
-    click.echo(f"Available: {len(available)}")
-    click.echo(f"Pending: {len(pending)}")
-    click.echo(f"Waiting: {len(waiting)}")
-    click.echo(f"Running: {len(running)}")
-    click.echo(f"Successful: {len(complete)}")
-    click.echo(f"Failed: {len(failed)}")
+    for key, value in tag_status.items():
+        click.echo(f"{key}: {len(value)}")
 
 
 def dirstats(path):


### PR DESCRIPTION
With the fragmented methods for getting running, pending, crashed, etc..., multiple slurm calls were required in order to get a full suite of status items (as needed for chp metrics). This method returns a dict with all status items, meaning that it should run faster