### PR TITLE
HFB data loader with selections

### DIFF
--- a/ch_pipeline/core/io.py
+++ b/ch_pipeline/core/io.py
@@ -42,11 +42,6 @@ from draco.core import task, io
 
 from . import containers
 
-try:
-    from ..hfb.io import HFBReader
-except ImportError:
-    HFBReader = None
-
 
 class LoadCorrDataFiles(task.SingleTask):
     """Load CHIME correlator data from a file list passed into the setup routine.
@@ -204,7 +199,7 @@ class LoadCorrDataFiles(task.SingleTask):
         return ts
 
 
-class LoadDataFiles(io.BaseLoadFiles):
+class LoadDataFiles(task.SingleTask):
     """Load general CHIME data from files passed into the setup routine.
 
     This does *not* support correlator data. Use `LoadCorrDataFiles` instead.
@@ -224,7 +219,6 @@ class LoadDataFiles(io.BaseLoadFiles):
         "gain": andata.CalibrationGainReader,
         "digitalgain": andata.DigitalGainReader,
         "flaginput": andata.FlagInputReader,
-        "hfb": HFBReader,
     }
 
     def setup(self, files):
@@ -234,9 +228,6 @@ class LoadDataFiles(io.BaseLoadFiles):
         ----------
         files : list
         """
-        # Call the baseclass setup to resolve any selections
-        super().setup()
-
         if self.acqtype not in self._acqtype_reader:
             raise ValueError(f'Specified acqtype "{self.acqtype}" is not supported.')
 
@@ -264,26 +255,8 @@ class LoadDataFiles(io.BaseLoadFiles):
         file_ = self.files[self._file_ptr]
         self._file_ptr += 1
 
-        # Handle file lists including time ranges
-        if isinstance(file_, tuple):
-            time_range = file_[1]
-            file_ = file_[0]
-        else:
-            time_range = (None, None)
-
         # Set up a Reader class
         rd = self._acqtype_reader[self.acqtype](file_)
-
-        # Select time range
-        rd.select_time_range(time_range[0], time_range[1])
-
-        # Select frequency range
-        if self._sel and "freq_sel" in self._sel:
-            rd.freq_sel = self._sel["freq_sel"]
-
-        # Select beams
-        if self._sel and "beam_sel" in self._sel:
-            rd.beam_sel = self._sel["beam_sel"]
 
         self.log.info(f"Reading file {self._file_ptr} of {len(self.files)}. ({file_})")
         ts = rd.read()

--- a/ch_pipeline/hfb/__init__.py
+++ b/ch_pipeline/hfb/__init__.py
@@ -7,5 +7,5 @@ CHIME HFB Pipeline
     :toctree:
 
     containers
-
+    io
 """

--- a/ch_pipeline/hfb/io.py
+++ b/ch_pipeline/hfb/io.py
@@ -1,0 +1,156 @@
+"""HFB tasks for reading and writing files
+"""
+
+import gc
+import numpy as np
+
+from caput import pipeline
+from caput import config
+
+from ch_util import ephemeris
+
+from draco.core import io
+
+from beam_model.formed import FFTFormedActualBeamModel
+
+from .containers import HFBReader
+
+
+class LoadHFBDataFiles(io.BaseLoadFiles):
+    """Load CHIME HFB data from a file list passed into the setup routine.
+
+    Attributes
+    ----------
+    source_dec : float
+        Declination of source in degrees.
+    freq_physical : list
+        List of physical frequencies (in MHz) to read. The first frequency
+        in this list is also used in evaluating beam positions (for selecting
+        the beams closest to a transiting source).
+
+    Selections
+    ----------
+    Selections in frequency and beams can be done in two ways:
+    1. By passing a `source_dec` attribute (for the beam selection) and/or
+       a `freq_physical` attribute (for the frequency selection).
+    2. By manually passing indices in the `selections` attribute
+       (see documentation in :class:`draco.core.io.BaseLoadFiles`).
+    Method 1 takes precedence over method 2. If no relevant attributes are
+    passed, all frequencies/beams are read.
+    """
+
+    files = None
+
+    _file_ptr = 0
+
+    source_dec = config.Property(proptype=float, default=None)
+    freq_physical = config.Property(proptype=list, default=[])
+
+    def setup(self, files):
+        """Set the list of files to load; set up frequency and beam selection.
+
+        Parameters
+        ----------
+        files : list
+        """
+        if not isinstance(files, (list, tuple)):
+            raise RuntimeError("Argument must be list of files.")
+
+        self.files = files
+
+        # Resolve any selections provided through the `selections` attribute
+        self._sel = self._resolve_sel()
+
+        # Set up frequency selection.
+        if self.freq_physical:
+            basefreq = np.linspace(800.0, 400.0, 1024, endpoint=False)
+            self.freq_sel = sorted(
+                set([np.argmin(np.abs(basefreq - freq)) for freq in self.freq_physical])
+            )
+        elif "freq_sel" in self._sel:
+            self.freq_sel = self._sel["freq_sel"]
+        else:
+            self.freq_sel = slice(None)
+
+        # Set up beam selection
+        if self.source_dec:
+            beam_index_ns = self._find_beam()
+            self.beam_sel = slice(beam_index_ns, 1024, 256)
+        elif "beam_sel" in self._sel:
+            self.beam_sel = self._sel["beam_sel"]
+        else:
+            self.beam_sel = slice(None)
+
+    def process(self):
+        """Load in each sidereal day.
+
+        Returns
+        -------
+        ts : HFBData
+            The timestream of each sidereal day.
+        """
+
+        if len(self.files) == self._file_ptr:
+            raise pipeline.PipelineStopIteration
+
+        # Collect garbage to remove any prior data objects
+        gc.collect()
+
+        # Fetch and remove the first item in the list
+        file_ = self.files[self._file_ptr]
+        self._file_ptr += 1
+
+        # Handle file lists including time ranges
+        if isinstance(file_, tuple):
+            time_range = file_[1]
+            file_ = file_[0]
+        else:
+            time_range = (None, None)
+
+        # Set up the reader
+        rd = HFBReader(file_)
+
+        # Select time range
+        rd.select_time_range(time_range[0], time_range[1])
+
+        # Select frequency range
+        rd.freq_sel = self.freq_sel
+
+        # Select beams
+        rd.beam_sel = self.beam_sel
+
+        # Read file(s)
+        self.log.info(f"Reading file {self._file_ptr} of {len(self.files)}. ({file_})")
+        ts = rd.read()
+
+        # Return timestream
+        return ts
+
+    def _find_beam(self):
+        """Find NS beam number of beam closest to source at transit
+
+        Returns
+        -------
+        beam_index_ns : int
+            North-south index of beam closest to source at transit.
+        """
+
+        # Find source's telescope-y coordinate
+        src_y = self.source_dec - ephemeris.CHIMELATITUDE
+
+        # Choose beam model
+        mdl = FFTFormedActualBeamModel()
+
+        # Grid of beam numbers with EW beam number 1
+        beams_ind = np.arange(1000, 1256)
+
+        # Decide frequency (in MHz) at which to evaluate beam positions
+        freq = self.freq_physical[0] if self.freq_physical else 600.0
+
+        # Find beam positions
+        beams_xy = mdl.get_beam_positions(beams_ind, freq).squeeze()
+
+        # Find NS beam number of beam closest to calibration source
+        beam_index_ns = np.abs(beams_xy[:, 1] - src_y).argmin()
+
+        return beam_index_ns

--- a/ch_pipeline/hfb/io.py
+++ b/ch_pipeline/hfb/io.py
@@ -17,7 +17,7 @@ from beam_model.formed import FFTFormedActualBeamModel
 from .containers import HFBReader
 
 
-class BaseLoadHFBDataFiles(io.BaseLoadFiles):
+class BaseLoadFiles(io.BaseLoadFiles):
     """Base class for loading CHIME HFB data from files on disk into containers.
 
     Attributes
@@ -122,14 +122,22 @@ class BaseLoadHFBDataFiles(io.BaseLoadFiles):
 
         return beam_index_ns
 
-    def _load_files(self, files, time_range=(None, None)):
-        # Load a file into the HFBData container.
+    def _load_filelist(self, files, time_range=(None, None)):
+        """Load a list of files into the HFBData container.
+
+        Parameters
+        ----------
+        files : list
+            List of filenames to load into container.
+        time_range: tuple
+            Unix timestamps bracketing the part of the data to be loaded.
+        """
 
         for filename in files:
             if not os.path.exists(filename):
                 raise RuntimeError(f"File does not exist: {filename}")
 
-        self.log.info(f"Loading file {files}")
+        self.log.info(f"Loading files {files}")
         self.log.debug(f"Reading with time range: {time_range}")
         self.log.debug(f"Reading with freq selections: {self.freq_sel}")
         self.log.debug(f"Reading with beam selections: {self.beam_sel}")
@@ -146,7 +154,7 @@ class BaseLoadHFBDataFiles(io.BaseLoadFiles):
         # Select beams
         rd.beam_sel = self.beam_sel
 
-        # Read file
+        # Read files
         cont = rd.read()
 
         if self.redistribute is not None:
@@ -155,61 +163,96 @@ class BaseLoadHFBDataFiles(io.BaseLoadFiles):
         return cont
 
 
-class LoadHFBDataFromFilelist(BaseLoadHFBDataFiles):
-    """Load CHIME HFB data from a file list passed into the setup routine."""
+class LoadFilesFromParams(BaseLoadFiles):
+    """Load CHIME HFB data from files given in the task's parameters.
 
-    files = None
+    Attributes
+    ----------
+    filegroups : list or dict
+        A dictionary specifying a file group, or a list of them. In addition to
+        the standard components of file groups ('tag' and 'files'; see documentation
+        in :class:`draco.core.io`), the file groups can also have a 'time_range',
+        given as a list of two unix timestamps. Example YAML content:
 
-    _file_ptr = 0
+    .. code-block:: yaml
 
-    def setup(self, files):
-        """Set the list of files to load; set up frequency and beam selection.
+        filegroups:
+          - tag: '20230108'
+            files: ['/mnt/gong/archive/20221221T181623Z_chime_hfb/hfb_01504956_0000.h5',
+                    '/mnt/gong/archive/20221221T181623Z_chime_hfb/hfb_01510110_0000.h5']
+            time_range: [1673156146.031947, 1673157946.031947]
+          - tag: '20230109'
+            files: ['/mnt/gong/archive/20221221T181623Z_chime_hfb/hfb_01592573_0000.h5']
+            time_range: [1673242310.130873, 1673244110.130873]
+    """
 
-        Parameters
-        ----------
-        files : list
-            List of lists of filenames, or list of tuples, where each tuple
-            consists of a list of filenames and a tuple of time bounds. Each
-            item in the main list will be places in a single HFBData container.
-        """
-        if not isinstance(files, (list, tuple)):
-            raise RuntimeError("Argument must be list of lists of files.")
+    filegroups = config.Property(proptype=io._list_of_filegroups)
 
-        self.files = files
-
-        # Call the baseclass setup to resolve any selections
-        super().setup()
+    _fgroup_ptr = 0
 
     def process(self):
-        """Load in each sidereal day.
+        """Load in each filegroup (e.g., a sidereal day).
 
         Returns
         -------
         ts : HFBData
-            The timestream of each sidereal day.
+            The timestream of each filegroup.
         """
 
-        if len(self.files) == self._file_ptr:
+        if len(self.filegroups) == self._fgroup_ptr:
             raise pipeline.PipelineStopIteration
 
         # Collect garbage to remove any prior data objects
         gc.collect()
 
         # Fetch and remove the first item in the list
-        file_ = self.files[self._file_ptr]
-        self._file_ptr += 1
+        filegroup = self.filegroups[self._fgroup_ptr]
+        self._fgroup_ptr += 1
 
-        # Handle file lists including time ranges
-        if isinstance(file_, tuple):
-            time_range = file_[1]
-            file_ = file_[0]
-        else:
-            time_range = (None, None)
+        if "time_range" not in filegroup:
+            filegroup["time_range"] = (None, None)
 
-        # Read file(s)
-        self.log.info(f"Reading file {self._file_ptr} of {len(self.files)}.")
-
-        ts = self._load_files(file_, time_range)
+        # Read filegroup
+        self.log.info(
+            f"Reading filegroup {self._fgroup_ptr} of {len(self.filegroups)}."
+        )
+        ts = self._load_filelist(filegroup["files"], filegroup["time_range"])
 
         # Return timestream
         return ts
+
+
+class LoadFiles(LoadFilesFromParams):
+    """Load CHIME HFB data from file lists passed into the setup routine."""
+
+    filelists = None
+
+    def setup(self, filelists):
+        """Convert lists of files to list of filegroups; set up frequency and beam selection.
+
+        Parameters
+        ----------
+        filelists : list
+            List of lists of filenames, or list of tuples, where each tuple
+            consists of a list of filenames and a tuple of time bounds. Each
+            item in the main list will be places in a single HFBData container.
+        """
+        if not isinstance(filelists, list):
+            raise RuntimeError("Argument must be list of lists of files.")
+
+        # Convert list of filelists to list of filegroups
+        self.filegroups = []
+        for i, flist in enumerate(filelists):
+
+            tag = f"group_{i}"
+
+            # Handle lists including time ranges
+            if isinstance(flist, tuple):
+                fgroup = {"files": flist[0], "time_range": flist[1], "tag": tag}
+            else:
+                fgroup = {"files": flist, "time_range": (None, None), "tag": tag}
+
+            self.filegroups.append(fgroup)
+
+        # Call the baseclass setup to resolve any selections
+        super().setup()

--- a/ch_pipeline/hfb/io.py
+++ b/ch_pipeline/hfb/io.py
@@ -23,8 +23,9 @@ class LoadHFBDataFiles(io.BaseLoadFiles):
     ----------
     source_dec : float
         Declination of source in degrees.
-    beam_ew_exclude : list
-        List of East-West beam indices (i.e., in the range 0-3) to exclude.
+    beam_ew_include : list
+        List of East-West beam indices (i.e., in the range 0-3) to include.
+        By default all four EW beams are included.
     freq_phys_range : list
         Start and stop of physical frequencies (in MHz) to read. The mean is
         used as reference frequency in evaluating beam positions (for selecting
@@ -52,7 +53,7 @@ class LoadHFBDataFiles(io.BaseLoadFiles):
     _file_ptr = 0
 
     source_dec = config.Property(proptype=float, default=None)
-    beam_ew_exclude = config.Property(proptype=list, default=[])
+    beam_ew_include = config.Property(proptype=list, default=None)
     freq_phys_list = config.Property(proptype=list, default=[])
     freq_phys_range = config.Property(proptype=list, default=[])
 
@@ -90,9 +91,8 @@ class LoadHFBDataFiles(io.BaseLoadFiles):
         if self.source_dec:
             beam_index_ns = self._find_beam()
             self.beam_sel = slice(beam_index_ns, 1024, 256)
-            if self.beam_ew_exclude:
-                beam_ew_include = list({0, 1, 2, 3} - set(self.beam_ew_exclude))
-                self.beam_sel = list(np.arange(1024)[self.beam_sel][beam_ew_include])
+            if self.beam_ew_include:
+                self.beam_sel = list(np.arange(1024)[self.beam_sel][self.beam_ew_include])
         elif "beam_sel" in self._sel:
             self.beam_sel = self._sel["beam_sel"]
         else:

--- a/ch_pipeline/hfb/io.py
+++ b/ch_pipeline/hfb/io.py
@@ -23,6 +23,8 @@ class LoadHFBDataFiles(io.BaseLoadFiles):
     ----------
     source_dec : float
         Declination of source in degrees.
+    beam_ew_exclude : list
+        List of East-West beam indices (i.e., in the range 0-3) to exclude.
     freq_phys_range : list
         Start and stop of physical frequencies (in MHz) to read. The mean is
         used as reference frequency in evaluating beam positions (for selecting
@@ -50,6 +52,7 @@ class LoadHFBDataFiles(io.BaseLoadFiles):
     _file_ptr = 0
 
     source_dec = config.Property(proptype=float, default=None)
+    beam_ew_exclude = config.Property(proptype=list, default=[])
     freq_phys_list = config.Property(proptype=list, default=[])
     freq_phys_range = config.Property(proptype=list, default=[])
 
@@ -87,6 +90,9 @@ class LoadHFBDataFiles(io.BaseLoadFiles):
         if self.source_dec:
             beam_index_ns = self._find_beam()
             self.beam_sel = slice(beam_index_ns, 1024, 256)
+            if self.beam_ew_exclude:
+                beam_ew_include = list({0, 1, 2, 3} - set(self.beam_ew_exclude))
+                self.beam_sel = list(np.arange(1024)[self.beam_sel][beam_ew_include])
         elif "beam_sel" in self._sel:
             self.beam_sel = self._sel["beam_sel"]
         else:


### PR DESCRIPTION
Allows selection of
- frequency indices based on physical frequency, and of
- beam numbers based on source declination.

The task works like this in the config file:
```
        -   type:       ch_pipeline.hfb.io.LoadHFBDataFiles
            requires:   qfilelist
            out:        tstream
            params:
                source_dec: -1.98729406393
                freq_physical: [467.336]
```
To select multiple frequency bins, multiple physical frequencies can be added to the list: the bins in which these frequencies fall will be added. Maybe it would be good to add a way to specify a range of physical frequencies to select. What do you think?

The task also accepts manual selection of indices, like this:
```
        -   type:       ch_pipeline.hfb.io.LoadHFBDataFiles
            requires:   qfilelist
            out:        tstream
            params:
                selections:
                    freq_range: [851, 853]
                    beam_range: [12, 1024, 256]
```

A combination also works, like this:
```
        -   type:       ch_pipeline.hfb.io.LoadHFBDataFiles
            requires:   qfilelist
            out:        tstream
            params:
                source_dec: -1.98729406393
                selections:
                    freq_range: [851, 853]
```

Perhaps look at PR #134 before this one.