### PR TITLE
Add config option to prioritize processing recent CSDs 

### DIFF
--- a/ch_pipeline/processing/base.py
+++ b/ch_pipeline/processing/base.py
@@ -348,10 +348,14 @@ class ProcessingType(object):
             Submit the jobs to the queue.
         """
 
-        to_run = self.pending()[:max]
+        to_run = self._generate_hook()[:max]
 
         for tag in to_run:
             queue_job(self.job_script(tag), submit=submit)
+
+    def _generate_hook(self):
+        """Override to add custom behaviour when jobs are queued."""
+        return self.pending()
 
     def pending(self, user=None):
         """Jobs available to run."""

--- a/ch_pipeline/processing/daily.py
+++ b/ch_pipeline/processing/daily.py
@@ -1,10 +1,10 @@
-import os
 import math
 import datetime
 
 import chimedb.core as db
-from ch_util import ephemeris
 import chimedb.data_index as di
+from ch_util import ephemeris
+from caput.tools import unique_ordered
 
 from . import base
 
@@ -586,6 +586,8 @@ class DailyProcessing(base.ProcessingType):
         ],
         # Amount of padding each side of sidereal day to load
         "padding": 0.02,
+        # Number of recent days to prioritize in queue
+        "num_recent_days_first": 0,
         # Frequencies to process
         "freq": [0, 1024],
         # The beam transfers to use (need to have the same freq range as above)
@@ -633,6 +635,7 @@ class DailyProcessing(base.ProcessingType):
             self._intervals.append((t["start"], t.get("end", None), t.get("step", 1)))
 
         self._padding = self._revparams["padding"]
+        self._num_recent_days = self._revparams.get("num_recent_days_first", 0)
 
     def _available_files(self, start_csd, end_csd):
         """
@@ -704,7 +707,7 @@ class DailyProcessing(base.ProcessingType):
         # files_that_exist might contain the same file multiple files
         # if it exists in multiple locations (nearline, online, gossec, etc)
         # we only want to include it once
-        filenames_that_exist = sorted(list(set(t for t in files_that_exist.tuples())))
+        filenames_that_exist = sorted({t for t in files_that_exist.tuples()})
 
         return filenames_online, filenames_that_exist
 
@@ -713,41 +716,38 @@ class DailyProcessing(base.ProcessingType):
 
         This includes any that currently exist or are in the job queue.
         """
-
-        csds = []
-
-        # For each interval find and add all CSDs that have not already been added
-        for interval in self._intervals:
-            csd_i = csds_in_range(*interval)
-            csd_set = set(csds)
-            csds += [csd for csd in csd_i if csd not in csd_set]
-
-        # grab the list of files that are online, and that exist anywhere, from the earliest csd to the latest
+        # Lets us get only unique csds in the order we want them
+        # with a single pass.
+        csds = unique_ordered(
+            # This is a generator
+            (csd for i in self._intervals for csd in csds_in_range(*i))
+        )
         csds_sorted = sorted(csds)
+
+        # grab the list of files that are online, and that exist anywhere,
+        # from the earliest csd to the latest
         filenames_online, filenames_that_exist = self._available_files(
             csds_sorted[0], csds_sorted[-1] + 1
         )
-
         # only queue jobs for which all data is available online in chime_online
         csds_available = self._csds_available_data(
             csds_sorted, filenames_online, filenames_that_exist
         )
-        csds = [csd for csd in csds if csd in csds_available]
 
-        tags = ["%i" % csd for csd in csds]
+        tags = [f"{csd:.0f}" for csd in csds if csd in csds_available]
 
         return tags
 
-    def _csds_available_data(self, csds, filenames_online, filenames_that_exist):
+    def _csds_available_data(self, csds, filenames_online, filenames_that_exist) -> set:
         """
         Return the subset of csds in `csds` for whom all files are online.
 
         `filenames_online` and `filenames_that_exist` are a list of tuples
         (start_time, finish_time)
 
-        All 3 lists should be sorted.
+        All 3 input lists should be sorted.
         """
-        csds_available = []
+        csds_available = set()
 
         for csd in csds:
             start_time = ephemeris.csd_to_unix(csd)
@@ -763,7 +763,7 @@ class DailyProcessing(base.ProcessingType):
             )
 
             if (len(online) == len(exists)) and (len(online) != 0):
-                csds_available.append(csd)
+                csds_available.add(csd)
 
             # The final file in the span may contain more than one sidereal day
             index_online = max(index_online - 1, 0)
@@ -812,6 +812,18 @@ class DailyProcessing(base.ProcessingType):
         jobparams.update({"csd": [csd - self._padding, csd + 1 + self._padding]})
 
         return jobparams
+
+    def _generate_hook(self):
+        to_run = self.pending()
+
+        if self._num_recent_days:
+            today = math.floor(ephemeris.chime.get_current_lsd())
+            priority = [
+                csd for csd in to_run if today - int(csd) <= self._num_recent_days
+            ]
+            to_run = priority + [csd for csd in to_run if csd not in priority]
+
+        return to_run
 
 
 class TestDailyProcessing(DailyProcessing):

--- a/ch_pipeline/processing/daily.py
+++ b/ch_pipeline/processing/daily.py
@@ -875,16 +875,15 @@ def csds_in_range(start, end, step=1):
     csds : list of ints
     """
 
-    if end is None:
-        end = datetime.datetime.utcnow()
-
     if start.startswith("CSD"):
         start_csd = int(start[3:])
     else:
         start_csd = ephemeris.unix_to_csd(ephemeris.ensure_unix(start))
         start_csd = math.floor(start_csd)
 
-    if end.startswith("CSD"):
+    if end is None:
+        end_csd = int(ephemeris.chime.get_current_lsd())
+    elif end.startswith("CSD"):
         end_csd = int(end[3:])
     else:
         end_csd = ephemeris.unix_to_csd(ephemeris.ensure_unix(end))


### PR DESCRIPTION
Adds a config option to check `n` recent days since the current CSD and process those days before others in the queue.

Also, fix a bug so the daily config can actually handle not being provided an end date for some CSD range. In this case, any data between `start` and the current CSD will be included in the queue. 

The idea here is that a daily pipeline revision can process the most recent days first as their data become available. Note that I've set the default config num days to zero, so it won't check for recent days by default. 