### PR TITLE
Remove `CHIMETimeStream` `.time` property and replace with a task to apply shift

### DIFF
--- a/ch_pipeline/analysis/timing.py
+++ b/ch_pipeline/analysis/timing.py
@@ -381,3 +381,45 @@ class ConstructTimingCorrection(task.SingleTask):
 
         # Return timing correction
         return tcorr
+
+
+class CentreTimeSamples(task.SingleTask):
+    """Apply a shift to container time samples.
+
+    Parameters
+    ----------
+    method : str [center, value]
+        How to shift the time samples. If `center`, samples are shifted
+        by half the absolute median difference. If `value`, samples are
+        shifted by the value of `shift` property.
+    shift : float
+        Shift to apply to the time samples, if `method` is `value`
+    """
+
+    direction = config.enum(["forward", "back"], default="forward")
+
+    def process(self, cont):
+        """Apply a shift to the container `time` property.
+
+        Parameters
+        ----------
+        cont : draco.core.containers.TODContainer, or container
+            which inherits from it
+
+        Returns
+        -------
+        cont : same container with `index_map` time shifted
+        """
+
+        # Extract the time array
+        time = cont.time[:]
+
+        # Gets the absolute centering shift
+        shift = abs(np.median(np.diff(time)) / 2)
+
+        if self.direction == "back":
+            shift *= -1
+
+        time += shift
+
+        return cont

--- a/ch_pipeline/core/containers.py
+++ b/ch_pipeline/core/containers.py
@@ -943,15 +943,6 @@ class RawContainer(TODContainer):
         parent_name, name = posixpath.split(name)
         return parent_name == "/" or self.group_name_allowed(parent_name)
 
-    @cached_property
-    def time(self) -> np.ndarray:
-        """The 'time' axis centres as Unix/POSIX time."""
-
-        time = self._data["index_map"]["time"]["ctime"].copy()
-        # Shift from lower edge to centres.
-        time += abs(np.median(np.diff(time)) / 2)
-        return time
-
     @classmethod
     def from_acq_h5(
         cls,


### PR DESCRIPTION
This fixes the issues described in #146. In summary, using the modified `.time` property results in potential incompatibilities with other tasks and `draco` containers which use the `.time` property. 

I'm open to thoughts about different ways to implement this, but with this task applied early in the daily pipeline all products will be fine. However, it would have to be applied to any processing or analysis that pulls directly from raw corr data rather than using daily pipeline products.