### PR TITLE
HFB data loading frequency selection fix

### DIFF
--- a/ch_pipeline/hfb/analysis.py
+++ b/ch_pipeline/hfb/analysis.py
@@ -205,7 +205,6 @@ class HFBStackDays(task.SingleTask):
         # If this is our first sidereal day, then initialize the
         # container that will hold the stack.
         if self.stack is None:
-
             self.stack = containers.empty_like(sdata)
 
             self.stack.add_dataset("nsample")
@@ -242,7 +241,6 @@ class HFBStackDays(task.SingleTask):
 
         # Compute weights and data
         if self.weighting == "uniform":
-
             # Number of days with non-zero weight
             norm = self.stack.nsample[:].astype(np.float32)
 
@@ -255,7 +253,6 @@ class HFBStackDays(task.SingleTask):
             self.stack.hfb[:] /= norm
 
         else:
-
             # For inverse variance weighting, the weight dataset doesn't have to
             # be normalized (it is simply the sum of the weights). The accumulated
             # data have to be normalized by the sum of the weights.

--- a/ch_pipeline/hfb/io.py
+++ b/ch_pipeline/hfb/io.py
@@ -26,7 +26,8 @@ class BaseLoadFiles(io.BaseLoadFiles):
         Declination of source in degrees.
     beam_ew_include : list
         List of East-West beam indices (i.e., in the range 0-3) to include.
-        By default all four EW beams are included.
+        By default all four EW beams are included. Does not work in combination
+        with `freq_phys_list`.
     freq_phys_range : list
         Start and stop of physical frequencies (in MHz) to read. The mean is
         used as reference frequency in evaluating beam positions (for selecting
@@ -34,7 +35,8 @@ class BaseLoadFiles(io.BaseLoadFiles):
     freq_phys_list : list
         List of physical frequencies (in MHz) to read. The first frequency
         in this list is also used in evaluating beam positions (for selecting
-        the beams closest to a transiting source).
+        the beams closest to a transiting source). Does not work in combination
+        with `beam_ew_include`.
 
     Selections
     ----------
@@ -63,8 +65,10 @@ class BaseLoadFiles(io.BaseLoadFiles):
         # Set up frequency selection.
         cfreq = np.linspace(800.0, 400.0, 1024, endpoint=False)
         if self.freq_phys_range:
-            freq_index_start = np.argmin(np.abs(cfreq - self.freq_phys_range[0]))
-            freq_index_stop = np.argmin(np.abs(cfreq - self.freq_phys_range[-1]))
+            freq_phys_start = np.max(self.freq_phys_range)
+            freq_phys_stop = np.min(self.freq_phys_range)
+            freq_index_start = np.argmin(np.abs(cfreq - freq_phys_start))
+            freq_index_stop = np.argmin(np.abs(cfreq - freq_phys_stop))
             self.freq_sel = slice(freq_index_start, freq_index_stop)
         elif self.freq_phys_list:
             self.freq_sel = sorted(


### PR DESCRIPTION
Small fix to make selecting frequencies (during data loading) more robust.

Also add some comments to the docstring to explain when selections don't work: using both `beam_ew_include` and `freq_phys_list`, with both having a length > 1, yields
```
TypeError: Only one indexing vector or array is currently allowed for fancy indexing
```