### PR TITLE
HFB move nsamples dataset

### DIFF
--- a/ch_pipeline/hfb/containers.py
+++ b/ch_pipeline/hfb/containers.py
@@ -212,13 +212,6 @@ class HFBTimeAverage(FreqContainer):
             "distributed": True,
             "distributed_axis": "freq",
         },
-        "nsample": {
-            "axes": ["freq", "subfreq", "beam"],
-            "dtype": np.uint16,
-            "initialise": False,
-            "distributed": True,
-            "distributed_axis": "freq",
-        },
     }
 
     @property
@@ -230,11 +223,6 @@ class HFBTimeAverage(FreqContainer):
     def weight(self) -> memh5.MemDataset:
         """The inverse variance weight dataset."""
         return self["weight"]
-
-    @property
-    def nsample(self) -> memh5.MemDataset:
-        """The number of non-zero samples."""
-        return self.datasets["nsample"]
 
 
 class HFBHighResData(TODContainer, FreqContainer):
@@ -319,6 +307,12 @@ class HFBHighResSpectrum(FreqContainer):
             "initialise": True,
             "distributed": False,
         },
+        "nsample": {
+            "axes": ["freq"],
+            "dtype": np.uint16,
+            "initialise": False,
+            "distributed": False,
+        },
     }
 
     @property
@@ -330,3 +324,8 @@ class HFBHighResSpectrum(FreqContainer):
     def weight(self) -> memh5.MemDataset:
         """The inverse variance weight dataset."""
         return self["hfb_weight"]
+
+    @property
+    def nsample(self) -> memh5.MemDataset:
+        """The number of non-zero samples."""
+        return self.datasets["nsample"]


### PR DESCRIPTION
Bug fix: `nsamples` should therefore be a dataset in the `HFBHighResSpectrum` container, because it is used by `HFBStackDays`.