### PR TITLE
HFB template local array

### DIFF
--- a/ch_pipeline/hfb/analysis.py
+++ b/ch_pipeline/hfb/analysis.py
@@ -147,12 +147,14 @@ class HFBDivideByTemplate(task.SingleTask):
             Container with HFB data and weights; the result of the division.
         """
 
+        template_local = template.hfb[:].local_array
+
         # Divide data by template
-        data = stream.hfb[:] * tools.invert_no_zero(template.hfb[:, :, :, np.newaxis])
+        data = stream.hfb[:] * tools.invert_no_zero(template_local[:, :, :, np.newaxis])
 
         # Divide variance by square of template, which means to
         # multiply weight by square of template
-        weight = stream.weight[:] * template.hfb[:, :, :, np.newaxis] ** 2
+        weight = stream.weight[:] * template_local[:, :, :, np.newaxis] ** 2
 
         # Create container to hold output
         out = containers.HFBData(axes_from=stream, attrs_from=stream)

--- a/ch_pipeline/hfb/analysis.py
+++ b/ch_pipeline/hfb/analysis.py
@@ -147,14 +147,14 @@ class HFBDivideByTemplate(task.SingleTask):
             Container with HFB data and weights; the result of the division.
         """
 
-        template_local = template.hfb[:].local_array
+        template_array = template.hfb[:]
 
         # Divide data by template
-        data = stream.hfb[:] * tools.invert_no_zero(template_local[:, :, :, np.newaxis])
+        data = stream.hfb[:] * tools.invert_no_zero(template_array[:, :, :, np.newaxis])
 
         # Divide variance by square of template, which means to
         # multiply weight by square of template
-        weight = stream.weight[:] * template_local[:, :, :, np.newaxis] ** 2
+        weight = stream.weight[:] * template_array[:, :, :, np.newaxis] ** 2
 
         # Create container to hold output
         out = containers.HFBData(axes_from=stream, attrs_from=stream)


### PR DESCRIPTION
Bug: `template.hfb[:, :, :, np.newaxis]` in `HFBDivideByTemplate` gives problems, because `template.hfb` is an `MPIArray`.

For now I fixed this by using `.local_array`, but maybe there's a better way.