### PR TITLE
HFB docs sdata type

### DIFF
--- a/ch_pipeline/hfb/analysis.py
+++ b/ch_pipeline/hfb/analysis.py
@@ -183,7 +183,7 @@ class HFBStackDays(task.SingleTask):
 
         Parameters
         ----------
-        sdata : hfb.containers.HFBTimeAverage, hfb.containers.HFBHighResTimeAverage
+        sdata : hfb.containers.HFBHighResSpectrum
             Individual (time-averaged) day to add to stack.
         """
 


### PR DESCRIPTION
Fix docstring of `HFBStackDays`: input `sdata` should be `HFBHighResSpectrum`, which has the `nsample` dataset