### PR TITLE
Frequency Map (1/2): Query database for frequency slot map

### DIFF
--- a/ch_pipeline/analysis/flagging.py
+++ b/ch_pipeline/analysis/flagging.py
@@ -1713,22 +1713,7 @@ class MaskDecorrelatedCylinder(task.SingleTask):
     threshold = config.Property(proptype=float, default=5.0)
     max_frac_freq = config.Property(proptype=float, default=0.1)
 
-    def setup(self, freq_map=None):
-        """Determine the frequencies handled by each FPGA motherboard slot.
-
-        If a motherboard decorrelates, then all frequencies transmitted by
-        that slot will be affected.
-
-        Parameters
-        ----------
-        freq_map : FrequencyMap
-            The mapping between frequency bin and [crate, slot, link]
-            as a function of time.
-        """
-
-        self._set_slot_freqs(freq_map)
-
-    def process(self, data, inputmap):
+    def process(self, data, inputmap, freqmap):
         """Create the mask.
 
         Parameters
@@ -1737,6 +1722,8 @@ class MaskDecorrelatedCylinder(task.SingleTask):
             Visibilites before averaging over cylinders.
         inputmap : list of :class:`CorrInput`
             A list describing the inputs in data.
+        freqmap : :class:`FrequencyMapSingle`
+            The mapping between frequency bin and [shuffle, crate, slot, link]
 
         Returns
         -------
@@ -1896,12 +1883,14 @@ class MaskDecorrelatedCylinder(task.SingleTask):
         # transmitted by that motherboard slot.  The cylinder decorrelation is
         # expected to affect all of these frequencies.  This step is only possible
         # if the frequency map as a function of time has been provided on setup.
-        if self.freq_map is not None and len(data.freq) == 1024:
-            grouper, slot_index = self._get_slot_freqs(data.time[0])
+
+        if freqmap is not None and len(data.freq) == 1024:
+            slot = freqmap.slot[:]
+            grouper = np.argsort(slot, kind="mergesort").reshape(max(slot) + 1, -1)
 
             frac_freq_masked = np.sum(mask[grouper, :], axis=1) / grouper.shape[1]
 
-            mask = mask | (frac_freq_masked > self.max_frac_freq)[slot_index, :]
+            mask = mask | (frac_freq_masked > self.max_frac_freq)[slot, :]
 
         # Print the fraction of data that has been masked by this task
         self.log.info(
@@ -1915,77 +1904,6 @@ class MaskDecorrelatedCylinder(task.SingleTask):
         out.mask[:] = mask
 
         return out
-
-    def _set_slot_freqs(self, freq_map):
-        """Determine the slot to frequency map as a function of time.
-
-        Parameters
-        ----------
-        freq_map : FrequencyMap
-            The mapping between frequency bin and [crate, slot, link]
-            as a function of time.
-        """
-
-        if freq_map is not None:
-            islot = list(freq_map.level).index("slot")
-            slot = freq_map.stream[:, :, islot]
-
-            nslot = np.max(slot) + 1
-            ntime, nfreq = slot.shape
-            nfreq_per_slot = nfreq // nslot
-
-            grouper = np.zeros((ntime, nslot, nfreq_per_slot), dtype=int)
-            for tt in range(ntime):
-                grouper[tt] = np.argsort(slot[tt], kind="mergesort").reshape(
-                    nslot, nfreq_per_slot
-                )
-
-            self.freq_map = freq_map
-            self.grouper = grouper
-            self.slot_index = slot
-
-        else:
-            self.freq_map = None
-
-    def _get_slot_freqs(self, timestamp):
-        """Look up the slot to frequency map that was used at a given time.
-
-        Parameters
-        ----------
-        timestamp : float64
-            Unix timestamp.
-
-        Returns
-        -------
-        grouper : np.ndarray[nslot, nfreq_per_slot]
-            Index into the frequency axis that will group
-            frequency channels based on the FPGA motherboard slot
-            that transmitted them.
-        slot_index : np.ndarray[nfreq,]
-            Index into the slot axis that will yield the
-            FPGA motherboard slot that transmitted each
-            frequency channel.
-        """
-
-        tindex = np.digitize(timestamp, self.freq_map.time) - 1
-
-        if tindex < 0:
-            tbefore = (self.freq_map.time.min() - timestamp) / (24 * 3600)
-            raise RuntimeError(
-                "Requested timestamp is before the earliest time "
-                f"in the frequency map file by {tbefore:0.1f} days."
-            )
-
-        if timestamp > self.freq_map.attrs["end_time"]:
-            tafter = (timestamp - self.freq_map.attrs["end_time"]) / (24 * 3600)
-            self.log.warning(
-                "Requested timestamp is after the end time covered "
-                f"by the frequency map file by {tafter:0.1f} days.  "
-                "Please ensure that the frequency map has not been "
-                "updated since then."
-            )
-
-        return self.grouper[tindex], self.slot_index[tindex]
 
 
 class ExpandMask(task.SingleTask):

--- a/ch_pipeline/core/containers.py
+++ b/ch_pipeline/core/containers.py
@@ -43,6 +43,70 @@ from draco.core.containers import (
 )
 
 
+class FrequencyMapSingle(FreqContainer):
+    """Map between frequency bin and FPGA [crate, slot, link].
+
+    This container holds a map between the frequency bins and stream ids.
+    A stream id is encoded based on the shuffle, crate, slot, and link values
+    as follows:
+
+    stream_id = shuffle*2**12 + crate*2**8 + slot*2**4 + link
+
+    The value of shuffle is always 3.
+    """
+
+    _axes = ("level",)
+
+    _dataset_spec = {
+        "stream": {
+            "axes": ["freq", "level"],
+            "dtype": np.int32,
+            "initialise": True,
+            "distributed": False,
+        },
+        "stream_id": {
+            "axes": ["freq"],
+            "dtype": np.int64,
+            "initialise": True,
+            "distributed": False,
+        },
+    }
+
+    def __init__(self, *args, **kwargs):
+        if "level" not in kwargs:
+            kwargs["level"] = np.array(["shuffle", "crate", "slot", "link"], dtype=str)
+
+        super().__init__(*args, **kwargs)
+
+    @property
+    def shuffle(self):
+        return self.stream[:, 0]
+
+    @property
+    def crate(self):
+        return self.stream[:, 1]
+
+    @property
+    def slot(self):
+        return self.stream[:, 2]
+
+    @property
+    def link(self):
+        return self.stream[:, 3]
+
+    @property
+    def stream(self):
+        return self.datasets["stream"]
+
+    @property
+    def stream_id(self):
+        return self.datasets["stream_id"]
+
+    @property
+    def level(self):
+        return self.index_map["level"]
+
+
 class FrequencyMap(FreqContainer, TODContainer):
     """Map between frequency bin and FPGA stream (GPU node) as a function of time."""
 

--- a/ch_pipeline/core/dataquery.py
+++ b/ch_pipeline/core/dataquery.py
@@ -37,13 +37,17 @@ in a dataspec YAML file, and loaded using :class:`LoadDataspec`. Example:
                 -   start:  2014-07-28 11:00:00
                     end:    2014-07-31 00:00:00
 """
+from __future__ import annotations
 
 import os
 
+import numpy as np
+
 from caput import mpiutil, config, pipeline
 from draco.core import task
-from chimedb import data_index as di
-from ch_util import tools, ephemeris, finder, layout
+from chimedb import data_index as di, dataset as ds
+from ch_util import tools, ephemeris, finder, layout, andata
+from ch_pipeline.core import containers
 
 
 _DEFAULT_NODE_SPOOF = {"cedar_online": "/project/rpp-krs/chime/chime_online/"}
@@ -653,6 +657,104 @@ class QueryInputs(task.MPILoggedTask):
         mpiutil.world.Barrier()
 
         return inputs
+
+
+class QueryFrequencyMap(task.MPILoggedTask):
+    """Get the CHIME frequency map that was active when this data was collected.
+
+    Attributes
+    ----------
+    cache : bool
+        Only query for the inputs for the first container received. For all
+        subsequent files just return the initial set of inputs. This can help
+        minimise the number of potentially fragile database operations.
+    """
+
+    cache = config.Property(proptype=bool, default=False)
+
+    _cached_inputs = None
+
+    def next(
+        self, ts: andata.CorrData | containers.CHIMETimeStream
+    ) -> containers.FrequencyMapSingle:
+        """Generate an input description from the timestream passed in.
+
+        Parameters
+        ----------
+        ts
+            Timestream container.
+
+        Returns
+        -------
+        freq_map
+            Frequency slot map container
+        """
+
+        # Fetch from the cache if we can
+        if self.cache and self._cached_inputs:
+            self.log.debug("Using cached inputs.")
+            return self._cached_inputs
+
+        stream_id = None
+        stream = None
+
+        if self.comm.rank == 0:
+            layout.connect_database()
+
+            # Get the dataset_id dataset, which will be None if it
+            # does not exist
+            if (dsid_flag := ts.flags.get("dataset_id", None)) is not None:
+                # Get only unique dataset ids to reduce number of lookups. Ignore
+                # the null dataset at the 0th index
+                unique_dataset_ids = np.unique(dsid_flag[:])[1:]
+
+                if len(unique_dataset_ids) != 0:
+                    fmaps = {}
+                    # Get the frequency map for each unique dataset_id. They should all
+                    # have the same frequency map - otherwise, raise an error
+                    for dsid in unique_dataset_ids:
+                        state = (
+                            ds.Dataset.from_id(str(dsid))
+                            .closest_ancestor_of_type("f_engine_frequency_map")
+                            .state
+                        )
+                        fmaps[state.id] = state.data
+
+                    if len(fmaps.keys()) > 1:
+                        raise ValueError(
+                            "Multiple frequency maps found for this dataset."
+                        )
+
+                    # Extract the stream_id and frequency map
+                    fmap_dict = list(fmaps.values())[0]["fmap"]
+
+                    stream_id = np.fromiter(fmap_dict.keys(), dtype=np.int64)
+                    fmap = np.array(list(fmap_dict.values()), dtype=np.int64)
+                    stream = tools.order_frequency_map_stream(fmap, stream_id)
+
+        # Broadcast to all ranks
+        stream_id = self.comm.bcast(stream_id, root=0)
+        stream = self.comm.bcast(stream, root=0)
+
+        # Check to see if we found a frequency map. If not, get the default mapping
+        if stream is None or stream_id is None:
+            stream, stream_id = tools.get_default_frequency_map_stream()
+            self.log.info("No frequency map found. Using default.")
+
+        # Set the frequency array for all 1024 frequencies, starting at 800 MHz
+        # The frequency map is only properly defined when all frequencies are used
+        freq = np.linspace(800, 400, 1024, endpoint=False)
+        cont = containers.FrequencyMapSingle(copy_from=ts, freq=freq)
+
+        cont.stream[:] = stream
+        cont.stream_id[:] = stream_id
+
+        # Save into the cache for the next iteration
+        if self.cache:
+            self.log.debug("Caching input.")
+            self._cached_inputs = cont
+
+        return cont
 
 
 def finder_from_spec(spec, node_spoof=None):

--- a/ch_pipeline/processing/daily.py
+++ b/ch_pipeline/processing/daily.py
@@ -84,13 +84,6 @@ pipeline:
         files: "{timing_file}"
         distributed: false
 
-    # Load the frequency map
-    - type: ch_pipeline.core.io.LoadSetupFile
-      out: freqmap
-      params:
-        filename: "{freqmap_file}"
-        distributed: false
-
     - type: draco.core.misc.AccumulateList
       in: tcorr
       out: tcorrlist
@@ -162,10 +155,16 @@ pipeline:
       in: full_bad_baseline_mask
       out: bad_baseline_mask
 
+    # Load the frequency map active when this data was collected
+    - type: ch_pipeline.core.dataquery.QueryFrequencyMap
+      in: tstream
+      out: freqmap
+      params:
+        cache: true
+
     # Identify decorrelated cylinders
     - type: ch_pipeline.analysis.flagging.MaskDecorrelatedCylinder
-      requires: freqmap
-      in: [tstream, inputmap]
+      in: [tstream, inputmap, freqmap]
       out: decorr_cyl_mask
       params:
         threshold: 5.0


### PR DESCRIPTION
Query the database for the frequency map that was active when a dataset was collected. Lookup is done by dataset_id, so older datasets which do not have a dataset_id will just use the default mapping that we assume was active at the time. 

Changes:
1.  Add a task to query the database for the frequency map corresponding to a dataset_id.
2.  Add a container type to hold a single frequency map. This does not modify the existing FrequencyMap container for backwards compatibility.
3. Modify the `MaskDecorrelatedCylinder` task to use the new container
4. Modify the daily config to use the new task(s)

Requires chime-experiment/ch_util#50