### PR TITLE
Timestamp Alignment(4/4): Remove `CHIMETimeStream.time` property

### DIFF
--- a/ch_pipeline/analysis/calibration.py
+++ b/ch_pipeline/analysis/calibration.py
@@ -1785,7 +1785,7 @@ class ThermalCalibration(task.SingleTask):
         else:
             timestamp = data.time[:]
             gain = containers.CommonModeGainData(
-                time=timestamp, axes_from=data, distributed=True, comm=data.comm
+                axes_from=data, distributed=True, comm=data.comm
             )
         # Redistribute
         gain.redistribute("freq")
@@ -2643,7 +2643,7 @@ class FlagNarrowbandGainError(task.SingleTask):
             # The input container has a time axis.  Use a singleton lsd axis.
             timestamp = data.time[np.newaxis, :]
 
-            out = containers.RFIMask(time=data.time, axes_from=data, attrs_from=data)
+            out = containers.RFIMask(axes_from=data, attrs_from=data)
 
         # Determine dimensions
         nfreq, ninput, nupdate = self.frac_error.shape

--- a/ch_pipeline/analysis/source_removal.py
+++ b/ch_pipeline/analysis/source_removal.py
@@ -369,8 +369,10 @@ class SolveSources(task.SingleTask):
             csd = data.attrs["lsd"] if "lsd" in data.attrs else data.attrs["csd"]
             csd = np.fix(np.mean(csd))
             timestamp = ephemeris.csd_to_unix(csd + data.ra / 360.0)
+            output_kwargs = {"time": timestamp}
         elif "time" in data.index_map:
             timestamp = data.time
+            output_kwargs = {}
         else:
             raise RuntimeError("Unable to extract time from input container.")
 
@@ -433,11 +435,11 @@ class SolveSources(task.SingleTask):
         # Create output container
         out = containers.SourceModel(
             pol=upol,
-            time=timestamp,
             source=np.array(self.sources),
             param=param_name,
             axes_from=data,
             attrs_from=data,
+            **output_kwargs
         )
 
         # Determine extended source model
@@ -842,8 +844,10 @@ class SolveSourcesWithBeam(SolveSources):
             csd = data.attrs["lsd"] if "lsd" in data.attrs else data.attrs["csd"]
             csd = np.fix(np.mean(csd))
             timestamp = ephemeris.csd_to_unix(csd + data.ra / 360.0)
+            output_kwargs = {"time": timestamp}
         elif "time" in data.index_map:
             timestamp = data.time
+            output_kwargs = {}
         else:
             raise RuntimeError("Unable to extract time from input container.")
 
@@ -906,11 +910,11 @@ class SolveSourcesWithBeam(SolveSources):
         # Create output container
         out = containers.SourceModel(
             pol=upol,
-            time=timestamp,
             source=np.array(self.sources),
             param=param_name,
             axes_from=data,
             attrs_from=data,
+            **output_kwargs
         )
 
         out.add_dataset("coeff")

--- a/ch_pipeline/core/containers.py
+++ b/ch_pipeline/core/containers.py
@@ -1001,15 +1001,6 @@ class RawContainer(TODContainer):
         parent_name, name = posixpath.split(name)
         return parent_name == "/" or self.group_name_allowed(parent_name)
 
-    @cached_property
-    def time(self) -> np.ndarray:
-        """The 'time' axis centres as Unix/POSIX time."""
-
-        time = self._data["index_map"]["time"]["ctime"].copy()
-        # Shift from lower edge to centres.
-        time += abs(np.median(np.diff(time)) / 2)
-        return time
-
     @classmethod
     def from_acq_h5(
         cls,


### PR DESCRIPTION
Removes the `.time` property from `containers.CHIMETimeStream`. This property is now properly implemented in `caput.tod.TOData` and is shifted based on the `.index_attrs["time"]["alignment"]` attribute.

Related PRs:
- https://github.com/radiocosmology/draco/pull/227
- https://github.com/radiocosmology/caput/pull/234
- https://github.com/chime-experiment/ch_util/pull/52