### PR TITLE
Dataset_id alternative 1 (1/1): Convert distributed `dataset_id` dataset to a type useable by h5py

### DIFF
--- a/ch_pipeline/analysis/calibration.py
+++ b/ch_pipeline/analysis/calibration.py
@@ -1803,8 +1803,8 @@ class ThermalCalibration(task.SingleTask):
         # results
         try:
             # First attempt to group all dataset_ids for all frequencies on
-            # rank=0 so it can do the full lookup
-            dataset_ids = data.flags["dataset_id"][:].gather(rank=0)
+            # rank=0 so it can do the full lookup.
+            dataset_ids = data.dataset_id[:].gather(rank=0)
 
             if self.comm.rank == 0:
                 # Try to use the dataset ID scheme in here, if the time range passed won't

--- a/ch_pipeline/core/containers.py
+++ b/ch_pipeline/core/containers.py
@@ -1061,6 +1061,14 @@ class CHIMETimeStream(TimeStream, RawContainer):
         return self["flags/frac_lost"]
 
     @property
+    def dataset_id(self):
+        """Get the dataset id flags dataset as U33 type."""
+        try:
+            return memh5.ensure_unicode(self["flags/dataset_id"][:])
+        except KeyError:
+            return None
+
+    @property
     def flags(self):
         """Get the flags group."""
         flags_group = dict(self["flags"])

--- a/ch_pipeline/core/containers.py
+++ b/ch_pipeline/core/containers.py
@@ -1002,7 +1002,7 @@ class CHIMETimeStream(TimeStream, RawContainer):
     _dataset_spec = {
         "flags/dataset_id": {
             "axes": ["freq", "time"],
-            "dtype": "U32",
+            "dtype": "S33",
             "initialise": False,
             "distributed": True,
         },
@@ -1046,6 +1046,12 @@ class CHIMETimeStream(TimeStream, RawContainer):
         if "/flags/inputs" in newdata:
             storage["input_flags"] = storage["flags"].pop("inputs")
             storage["input_flags"]._name = "/input_flags"
+
+        if "/flags/dataset_id" in newdata:
+            # Replace the dataset with data converted to a bytestring
+            dataset_id = storage["flags"].pop("dataset_id")
+            newdata.add_dataset("flags/dataset_id")
+            newdata["/flags/dataset_id"][:] = memh5.ensure_bytestring(dataset_id[:])
 
         return newdata
 


### PR DESCRIPTION
Converts `dataset_id` to be stored with `S33` type, which can be handled by h5py. Also introduces a property to access the dataset_id dataset converted to numpy unicode.