### PR TITLE
fix(build): add pytz to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ ch_util @ git+https://github.com/chime-experiment/ch_util.git
 cora @ git+https://github.com/radiocosmology/cora.git
 driftscan @ git+https://github.com/radiocosmology/driftscan.git
 draco @ git+https://github.com/radiocosmology/draco.git
+pytz


### PR DESCRIPTION
This is a requirement for ch_pipeline that doesn't actually get installed with ch_pipeline