### PR TITLE
Dataset_id (2/2): Ensure CHIMETimeStream datasets are accurate and handle distributed `dataset_id`

### DIFF
--- a/ch_pipeline/analysis/calibration.py
+++ b/ch_pipeline/analysis/calibration.py
@@ -1804,7 +1804,7 @@ class ThermalCalibration(task.SingleTask):
         try:
             # First attempt to group all dataset_ids for all frequencies on
             # rank=0 so it can do the full lookup
-            dataset_ids = data.flags["dataset_id"][:].gather(rank=0)
+            dataset_ids = data.dataset_id[:].gather(rank=0)
 
             if self.comm.rank == 0:
                 # Try to use the dataset ID scheme in here, if the time range passed won't

--- a/ch_pipeline/core/containers.py
+++ b/ch_pipeline/core/containers.py
@@ -1066,7 +1066,7 @@ class CHIMETimeStream(TimeStream, RawContainer):
     _dataset_spec = {
         "flags/dataset_id": {
             "axes": ["freq", "time"],
-            "dtype": "U32",
+            "dtype": "S32",
             "initialise": False,
             "distributed": True,
         },
@@ -1130,6 +1130,11 @@ class CHIMETimeStream(TimeStream, RawContainer):
     def frac_lost(self):
         """Get the input flags dataset."""
         return self["flags/frac_lost"]
+
+    @cached_property
+    def dataset_id(self):
+        """Get the dataset_id dataset in Unicode."""
+        return memh5.ensure_unicode(self["flags/dataset_id"][:])
 
     @property
     def flags(self):

--- a/ch_pipeline/core/containers.py
+++ b/ch_pipeline/core/containers.py
@@ -1131,10 +1131,13 @@ class CHIMETimeStream(TimeStream, RawContainer):
         """Get the input flags dataset."""
         return self["flags/frac_lost"]
 
-    @cached_property
+    @property
     def dataset_id(self):
         """Get the dataset_id dataset in Unicode."""
-        return memh5.ensure_unicode(self["flags/dataset_id"][:])
+        dsid = memh5.ensure_unicode(self["flags/dataset_id"][:])
+        dsid.flags.writeable = False
+
+        return dsid
 
     @property
     def flags(self):

--- a/ch_pipeline/core/containers.py
+++ b/ch_pipeline/core/containers.py
@@ -1143,8 +1143,11 @@ class CHIMETimeStream(TimeStream, RawContainer):
 
         # Alias the groups back in for maximum compatibility with CHIME Andata
         # based code
-        flags_group["vis_weight"] = self["vis_weight"]
-        flags_group["input_flags"] = self["input_flags"]
+        if "vis_weight" in self:
+            flags_group["vis_weight"] = self["vis_weight"]
+
+        if "input_flags" in self:
+            flags_group["input_flags"] = self["input_flags"]
 
         return flags_group
 

--- a/ch_pipeline/core/containers.py
+++ b/ch_pipeline/core/containers.py
@@ -1111,6 +1111,19 @@ class CHIMETimeStream(TimeStream, RawContainer):
             storage["input_flags"] = storage["flags"].pop("inputs")
             storage["input_flags"]._name = "/input_flags"
 
+        # Remove any datasets/flags which shouldn't be present in this container.
+        # If any other dataset is needed, then a CorrData container should be used
+        # or a new dataset_spec entry should be added to this container. At present,
+        # this should only affect the "frac_rfi" flag.
+        contains = set(newdata.datasets) | {
+            "flags/" + name for name in newdata["flags"]
+        }
+
+        for name in contains:
+            if name not in newdata.dataset_spec:
+                del newdata[name]
+                continue
+
         return newdata
 
     @property


### PR DESCRIPTION
This PR does some things:
1. Ensures that `CHIMETimeStream` containers will only have datasets set in its spec, and that those datasets will be of the correct type when inheriting from `andata.CorrData` containers. This only affects the `flags/frac_rfi` dataset, which isn't use via the draco containers interface as far as I can tell. If it is needed, then a dataset_spec entry should be added for it.
2. Access `dataset_id` in unicode via a property on `CHIMETimeStream`
3. Properly call `dataset_id` wherever it's used
4. Fix a bug where `CHIMETimeStream.flags` would throw an error if certain datasets weren't present

Requires chime-experiment/ch_util#53