### PR TITLE
HFB select on-source and off-source data

### DIFF
--- a/ch_pipeline/hfb/analysis.py
+++ b/ch_pipeline/hfb/analysis.py
@@ -9,6 +9,13 @@ On-source data selection is based on 2 criteria:
 1) The source must be inside the main lobe of synthetic beam.
 2) Sensitivity of the beam toward the source must be greater than some threshold. 
 
+A few points about sensitivity for on-source data selection:
+
+Sensitivity of the last row of EW beams is higher in side lobes than the main lobe. So if we take maximum sensitivity
+of the beam to calculate the threshold needed for data selection, selected data won't be in the main lobe. Therefore,
+for setting sensitivity threshold, closest sample to the centre of the beam is chosen (this sample is closest to the
+transit time through centre of the beam). Then, sensitivity corresponding to this sample is the maximum sensitivity 
+we want for setting the threshold for on-source data selection
 
 
 

--- a/ch_pipeline/hfb/analysis.py
+++ b/ch_pipeline/hfb/analysis.py
@@ -571,6 +571,11 @@ class HFBSelectTransit(task.SingleTask):
         mask = np.swapaxes(mask, 0, 2)
         mask = mask.reshape(nfreq, nsubfreq, nbeam, ntime)
 
+        self.log.info(
+            f"Average number of {self.selection} time samples selected: "
+            f"{mask.sum(axis=3).mean():.1f}"
+        )
+
         # Create container to hold output
         out = containers.HFBData(copy_from=stream)
 

--- a/ch_pipeline/hfb/analysis.py
+++ b/ch_pipeline/hfb/analysis.py
@@ -1,4 +1,17 @@
-"""Tasks for HFB analysis
+"""
+Task for selecting on- and off-source data. 
+beam_width gives the width of the synthetic beam. To select off-source data, a window around the beam is chosen.
+Size of this window is determined by "w" parameter: window size = w * beam_width
+Normally, when w ~ 18, the source is outside of the sideloebes of the beam.  Data outside this window is taken as 
+off-source data.
+On-source data selection is based on 2 criteria: 
+
+1) The source must be inside the main lobe of synthetic beam.
+2) Sensitivity of the beam toward the source must be greater than some threshold. 
+
+
+
+
 """
 import numpy as np
 

--- a/ch_pipeline/hfb/analysis.py
+++ b/ch_pipeline/hfb/analysis.py
@@ -11,11 +11,14 @@ On-source data selection is based on 2 criteria:
 
 A few points about sensitivity for on-source data selection:
 
-Sensitivity of the last row of EW beams is higher in side lobes than the main lobe. So if we take maximum sensitivity
-of the beam to calculate the threshold needed for data selection, selected data won't be in the main lobe. Therefore,
-for setting sensitivity threshold, closest sample to the centre of the beam is chosen (this sample is closest to the
-transit time through centre of the beam). Then, sensitivity corresponding to this sample is the maximum sensitivity 
-we want for setting the threshold for on-source data selection
+i) Sensitivity of the last row of EW beams is higher in the side lobes than the main lobe. That is why So if we take maximum
+sensitivity of the beam to calculate the threshold needed for data selection, selected data won't be in the main lobe. 
+Therefore, for setting sensitivity threshold, closest sample to the centre of the beam is chosen (this sample 
+is closest to the transit time through the centre beam centre). Then, sensitivity corresponding to this sample is the 
+maximum sensitivity we want for setting up the threshold for on-source data selection.
+
+ii) sensitivity 
+
 
 
 
@@ -452,7 +455,8 @@ class HFBtransit(task.SingleTask):
             #Swap axes to have (freq,beam,time), reshape it to have subfreq, and multiply sens by data, weight and time
             sens = np.swapaxes(sens,0,2)
             sens = sens.reshape(nfreq, 128, nbeam, len(time))
-            data = data*sens
+            
+            #change the weights to select off-source data
             weight = weight*sens
 
         #on-source data:
@@ -487,7 +491,7 @@ class HFBtransit(task.SingleTask):
             sens = np.swapaxes(sens,0,2)
             sens = sens.reshape(nfreq, 128, nbeam, len(time))
 
-            data = data*sens
+            #change the weights to select on-source data
             weight = weight*sens
 
         

--- a/ch_pipeline/hfb/analysis.py
+++ b/ch_pipeline/hfb/analysis.py
@@ -407,7 +407,7 @@ class HFBSelectTransit(task.SingleTask):
             Array consisting of transit data
         """
         formed_beam = beam_model.formed.FFTFormedBeamModel()
-        tied = beam_model.composite.FutureMostAccurateCompositeBeamModel()
+        tied = beam_model.composite.FutureMostAccurateCompositeBeamModel(interpolate_bad_freq=True)
 
         # Extract beam indices, change format for sensitivity calculations
         # For example, change [12, 268, 524, 780] to [  12, 1012, 2012, 3012]


### PR DESCRIPTION
This is mostly a refactor of Arash's work on the `HFBSelectTransit` task, but it also makes a few changes:
- It makes the data selection more flexible: the user can specify what criteria (sensitivity, offset from transit time) to use to determine what data is selected, and what parameters (magic numbers) to use for those criteria.
- Selecting the maximum sensitivity in the main lobe of a beam is done by first selecting the main lobe and then taking the maximum of the sensitivities in that selection, rather than taking the sensitivity at the sample closest to transit. This change means the there will be slight changes in what data is selected.

Obtaining the RA and Dec from the HFB target list catalog (rather than the current manual entry) will be done in a future PR.