### PR TITLE
fix(telescope): remove deprecated np.str type

### DIFF
--- a/ch_pipeline/core/telescope.py
+++ b/ch_pipeline/core/telescope.py
@@ -413,7 +413,7 @@ class CHIME(telescope.PolarisedTelescope):
                     return "Y"
             return "N"
 
-        return np.asarray([_pol(f) for f in self.feeds], dtype=np.str)
+        return np.asarray([_pol(f) for f in self.feeds], dtype=str)
 
     #
     # === Setup the primary beams ===


### PR DESCRIPTION
This seems to have been officially removed in recent versions, so it throws an attribute error in python 3.11 environments. `np.str` was already just an alias for the builtin `str` type