### PR TITLE
feat(mkvenv.sh): rewrite to add features and flexibility

### DIFF
--- a/mkvenv.sh
+++ b/mkvenv.sh
@@ -1,6 +1,95 @@
 #!/bin/bash
 
-virtualenv --system-site-packages  --prompt='(pipeline)' ./venv
-source ./venv/bin/activate
-pip install -r requirements.txt
-python setup.py develop
+# Set default values
+venv_name="ch-pipeline"
+venv_path="./venv"
+code_path="./venv/src"
+ignore_system="false"
+install_chpipeline_in_code_path="false"
+
+help_message="
+    $(basename $0) [-n VENV_NAME] [-v VENV_PATH] [-e CODE_PATH] [-i] [-c] \n\n
+    -n  \t Virtual environment name that will appear in your terminal prompt when activated. \n
+        \t\t Defaults to '$venv_name'. \n
+    -v  \t Path where virtual environment will be installed. \n
+        \t\t Defaults to '$venv_path'. \n
+    -e  \t Path where packages will be cloned for development. \n
+        \t\t Defaults to '$code_path'. \n
+    -i  \t Ignore packages already installed on your system, i.e., install all dependencies. \n
+    -c  \t Also install ch_pipeline into path where other CHIME/radiocosmology packages are cloned. \n
+"
+
+# Parse any options provided by user
+while getopts 'hn:v:e:ic' OPTION; do
+    case "$OPTION" in
+        n)
+            venv_name="($OPTARG)"
+            ;;
+
+        v)
+            venv_path="$OPTARG"
+            ;;
+
+        e)
+            code_path="$OPTARG"
+            ;;
+
+        i)
+            ignore_system="true"
+            ;;
+
+        c)
+            install_chpipeline_in_code_path="true"
+            ;;
+
+        h)
+            echo -e $help_message >&2
+            exit 1
+            ;;
+
+        ?)
+            echo -e $help_message >&2
+            exit 1
+            ;;
+    esac
+done
+shift "$(($OPTIND -1))"
+
+# Create and source the virtual environment
+if ${ignore_system}; then
+    virtualenv --prompt=$venv_name $venv_path
+else
+    virtualenv --system-site-packages --prompt=$venv_name $venv_path
+fi
+source $venv_path/bin/activate
+
+# Create requirements.txt file for pip.
+# We need a custom requirements file because the one bundled with ch_pipeline does
+# not allow editable installs, but we'd like the radiocosmology and CHIME codes to be
+# installed in an easily-accessible directory.
+# If we'd like ch_pipeline to be cloned into the venv src directory, we add an
+# appropriate line to the requirements file.
+requirements="
+    cython\n
+    pytz\n
+    -e git+https://github.com/radiocosmology/caput.git#egg=caput\n
+    -e git+https://github.com/chime-experiment/ch_util.git#egg=ch_util\n
+    -e git+https://github.com/radiocosmology/cora.git#egg=cora\n
+    -e git+https://github.com/radiocosmology/driftscan.git#egg=driftscan\n
+    -e git+https://github.com/radiocosmology/draco.git#egg=draco\n
+"
+chp_requirement="-e git+https://github.com/chime-experiment/ch_pipeline.git#egg=ch_pipeline"
+if ${install_chpipeline_in_code_path}; then
+    requirements="${requirements}${chp_requirement}"
+fi
+echo -e $requirements > ${venv_path}/venv_requirements.txt
+
+# Install the packages
+mkdir $code_path
+pip install --use-deprecated=legacy-resolver --src $code_path -r ${venv_path}/venv_requirements.txt
+
+# If not cloning ch_pipeline into the src directory, perform an editable install that
+# keeps ch_pipeline where it is
+if ! ${install_chpipeline_in_code_path}; then
+    pip install -e .
+fi


### PR DESCRIPTION
The `mkvenv.sh` script has not been updated since 2014, and has several undesirable behaviors:

1. There is no flexibility in the name or location of the `venv` directory.
2. CHIME/radiocosmology packages are installed into `venv/lib/pythonX.X/site-packages`, but it would be better to have editable installs that are more easily accessible.
3. There is no option to ignore system-site-packages, but for inexperienced Python users and/or people installing onto their own computer, using system-site-packages can sometimes lead to conflicts.
4. `python setup.py develop` is used, but this is now deprecated (see https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html) and results in deprecation warnings when the script is run
5. Since virtualenv v20.10.0, using `--prompt='(pipeline)'` actually results in a prompt of `((pipeline))` (see https://virtualenv.pypa.io/en/latest/changelog.html#features-20-10-0)
6. All CHIME/radiocosmology are installed into the venv in the same way, *except* ch_pipeline, which is installed in-place. This is not necessarily undesirable, but I think it would be nice to have the option to install all packages in the same way, such that there's a `src` directory that contains ch_pipeline along with ch_util, draco, etc.

This PR rewrites the script, building off a very nice script that @ssiegelx wrote for CHORD. The above behaviors are addressed as follows:

1. Adding a command-line option to specify the directory where the venv will be stored.
2. Adding a command-line option to specify the directory where CHIME/radiocosmology packages will be installed as editable installs. The current `requirements.txt` doesn't allow for editable installs of these packages without changing `requirements.txt` itself (at least, I tried to find a way to do it and failed), but I didn't want to touch `requirements.txt` for fear of breaking the CI tests or something else. Instead, I've implemented a somewhat clumsy solution of creating a different `requirements.txt` that is used solely by this script and allows editable installs of the relevant repositories. If there's a better way to handle this, I'd appreciate any feedback.
3. Adding a command-line option to ignore system-site-packages.
4. Replacing `python setup.py develop` with `pip install -e .`, which does the same thing but is standards-compliant.
5. Changing the prompt argument of virtualenv such that the command-line prompt ends up being `(ch-pipeline)` with the newest version of virtualenv.
6. Adding a command-line option to perform an editable install of ch_pipeline into the venv src directory. (If this is chosen, we actually don't need the version of ch_pipeline that was cloned in order to run the mkvenv.sh script. We could consider housing mkvenv.sh to a separate public repository, but it might be easier to keep it bundled with ch_pipeline...feedback on this is welcome as well.)

Why all this fuss, when Richard has put all this work into mkchimeenv, which exists as a separate repository?
1. The ch_pipeline readme clearly states that `mkvenv.sh` should be used, so we should make sure it works nicely.
2. `mkchimeenv` requires that the user is a member of chime-experiment on GitHub, but we should also have a way for non-members to easily install CHIME/radiocosmology codes. (For example, a student who might be doing a simulation-based project that doesn't need access to CHIME-internal information.) Appropriate options could be added to `mkchimeenv`, but then we'd want to make it public, so it seems easiler to just make sure that `mkvenv.sh` works.