### PR TITLE
refactor(hfb): create base HFB container

### DIFF
--- a/ch_pipeline/hfb/containers.py
+++ b/ch_pipeline/hfb/containers.py
@@ -245,8 +245,12 @@ class HFBTimeAverage(FreqContainer, HFBContainer):
     }
 
 
-class HFBHighResData(TODContainer, FreqContainer, HFBContainer):
-    """Container for holding high-resolution frequency data"""
+class HFBHighResContainer(FreqContainer, HFBContainer):
+    """Base class for HFB containers with high-resolution frequency data."""
+
+
+class HFBHighResData(TODContainer, HFBHighResContainer):
+    """Container for holding high-resolution frequency data."""
 
     _axes = ("beam",)
 
@@ -274,8 +278,8 @@ class HFBHighResData(TODContainer, FreqContainer, HFBContainer):
     }
 
 
-class HFBHighResTimeAverage(FreqContainer, HFBContainer):
-    """Container for holding time-averaged high-resolution frequency data"""
+class HFBHighResTimeAverage(HFBHighResContainer):
+    """Container for holding time-averaged high-resolution frequency data."""
 
     _axes = ("beam",)
 
@@ -303,8 +307,8 @@ class HFBHighResTimeAverage(FreqContainer, HFBContainer):
     }
 
 
-class HFBHighResSpectrum(FreqContainer, HFBContainer):
-    """Container for holding high-resolution frequency spectrum"""
+class HFBHighResSpectrum(HFBHighResContainer):
+    """Container for holding high-resolution frequency spectrum."""
 
     _dataset_spec = {
         "hfb": {

--- a/ch_pipeline/hfb/containers.py
+++ b/ch_pipeline/hfb/containers.py
@@ -10,15 +10,15 @@ from caput import memh5
 
 from ch_util import andata
 
-from ..core.containers import RawContainer, FreqContainer
+from ..core.containers import ContainerBase, RawContainer, FreqContainer
 
 from draco.core.containers import TODContainer
 
 
-class HFBContainer(FreqContainer):
+class HFBContainer(ContainerBase):
     """A base class for all HFB containers.
 
-    Like :class:`FreqContainer`, but with some properties specific to HFB data.
+    Like :class:`ContainerBase`, but with some properties specific to HFB data.
     """
 
     @property
@@ -43,7 +43,7 @@ class HFBContainer(FreqContainer):
         return self.datasets["nsample"]
 
 
-class HFBData(RawContainer, HFBContainer):
+class HFBData(RawContainer, FreqContainer, HFBContainer):
     """A container for HFB data.
 
     This attempts to wrap the HFB archive format.
@@ -216,7 +216,7 @@ class HFBRFIMask(TODContainer, FreqContainer):
         return self.datasets["sens"]
 
 
-class HFBTimeAverage(HFBContainer):
+class HFBTimeAverage(FreqContainer, HFBContainer):
     """Container for holding average data for flattening sub-frequency band shape."""
 
     _axes = ("subfreq", "beam")
@@ -245,7 +245,7 @@ class HFBTimeAverage(HFBContainer):
     }
 
 
-class HFBHighResData(TODContainer, HFBContainer):
+class HFBHighResData(TODContainer, FreqContainer, HFBContainer):
     """Container for holding high-resolution frequency data"""
 
     _axes = ("beam",)
@@ -274,7 +274,7 @@ class HFBHighResData(TODContainer, HFBContainer):
     }
 
 
-class HFBHighResTimeAverage(HFBContainer):
+class HFBHighResTimeAverage(FreqContainer, HFBContainer):
     """Container for holding time-averaged high-resolution frequency data"""
 
     _axes = ("beam",)
@@ -303,7 +303,7 @@ class HFBHighResTimeAverage(HFBContainer):
     }
 
 
-class HFBHighResSpectrum(HFBContainer):
+class HFBHighResSpectrum(FreqContainer, HFBContainer):
     """Container for holding high-resolution frequency spectrum"""
 
     _dataset_spec = {

--- a/ch_pipeline/hfb/containers.py
+++ b/ch_pipeline/hfb/containers.py
@@ -29,7 +29,13 @@ class HFBContainer(FreqContainer):
     @property
     def weight(self) -> memh5.MemDataset:
         """The inverse variance weight dataset."""
-        return self["weight"] if "weight" in self else self["flags/hfb_weight"]
+        if "weight" in self:
+            weight = self["weight"]
+        elif "hfb_weight" in self:
+            weight = self["hfb_weight"]
+        else:
+            weight = self["flags/hfb_weight"]
+        return weight
 
     @property
     def nsample(self) -> memh5.MemDataset:

--- a/ch_pipeline/hfb/containers.py
+++ b/ch_pipeline/hfb/containers.py
@@ -15,7 +15,29 @@ from ..core.containers import RawContainer, FreqContainer
 from draco.core.containers import TODContainer
 
 
-class HFBData(RawContainer, FreqContainer):
+class HFBContainer(FreqContainer):
+    """A base class for all HFB containers.
+
+    Like :class:`FreqContainer`, but with some properties specific to HFB data.
+    """
+
+    @property
+    def hfb(self) -> memh5.MemDataset:
+        """The main hfb dataset."""
+        return self.datasets["hfb"]
+
+    @property
+    def weight(self) -> memh5.MemDataset:
+        """The inverse variance weight dataset."""
+        return self["weight"] if "weight" in self else self["flags/hfb_weight"]
+
+    @property
+    def nsample(self) -> memh5.MemDataset:
+        """The number of non-zero samples."""
+        return self.datasets["nsample"]
+
+
+class HFBData(RawContainer, HFBContainer):
     """A container for HFB data.
 
     This attempts to wrap the HFB archive format.
@@ -60,21 +82,6 @@ class HFBData(RawContainer, FreqContainer):
             "distributed": True,
         },
     }
-
-    @property
-    def hfb(self) -> memh5.MemDataset:
-        """The main hfb dataset."""
-        return self.datasets["hfb"]
-
-    @property
-    def weight(self) -> memh5.MemDataset:
-        """The inverse variance weight dataset."""
-        return self["flags/hfb_weight"]
-
-    @property
-    def nsample(self) -> memh5.MemDataset:
-        """The number of non-zero samples."""
-        return self.datasets["nsample"]
 
 
 class HFBReader(tod.Reader):
@@ -203,7 +210,7 @@ class HFBRFIMask(TODContainer, FreqContainer):
         return self.datasets["sens"]
 
 
-class HFBTimeAverage(FreqContainer):
+class HFBTimeAverage(HFBContainer):
     """Container for holding average data for flattening sub-frequency band shape."""
 
     _axes = ("subfreq", "beam")
@@ -231,23 +238,8 @@ class HFBTimeAverage(FreqContainer):
         },
     }
 
-    @property
-    def hfb(self) -> memh5.MemDataset:
-        """The main hfb dataset."""
-        return self.datasets["hfb"]
 
-    @property
-    def weight(self) -> memh5.MemDataset:
-        """The inverse variance weight dataset."""
-        return self["weight"]
-
-    @property
-    def nsample(self) -> memh5.MemDataset:
-        """The number of non-zero samples."""
-        return self.datasets["nsample"]
-
-
-class HFBHighResData(TODContainer, FreqContainer):
+class HFBHighResData(TODContainer, HFBContainer):
     """Container for holding high-resolution frequency data"""
 
     _axes = ("beam",)
@@ -260,7 +252,7 @@ class HFBHighResData(TODContainer, FreqContainer):
             "distributed": True,
             "distributed_axis": "freq",
         },
-        "hfb_weight": {
+        "weight": {
             "axes": ["freq", "beam", "time"],
             "dtype": np.float32,
             "initialise": True,
@@ -275,23 +267,8 @@ class HFBHighResData(TODContainer, FreqContainer):
         },
     }
 
-    @property
-    def hfb(self) -> memh5.MemDataset:
-        """The main hfb dataset."""
-        return self.datasets["hfb"]
 
-    @property
-    def weight(self) -> memh5.MemDataset:
-        """The inverse variance weight dataset."""
-        return self["hfb_weight"]
-
-    @property
-    def nsample(self) -> memh5.MemDataset:
-        """The number of non-zero samples."""
-        return self.datasets["nsample"]
-
-
-class HFBHighResTimeAverage(FreqContainer):
+class HFBHighResTimeAverage(HFBContainer):
     """Container for holding time-averaged high-resolution frequency data"""
 
     _axes = ("beam",)
@@ -304,7 +281,7 @@ class HFBHighResTimeAverage(FreqContainer):
             "distributed": True,
             "distributed_axis": "freq",
         },
-        "hfb_weight": {
+        "weight": {
             "axes": ["freq", "beam"],
             "dtype": np.float32,
             "initialise": True,
@@ -319,23 +296,8 @@ class HFBHighResTimeAverage(FreqContainer):
         },
     }
 
-    @property
-    def hfb(self) -> memh5.MemDataset:
-        """The main hfb dataset."""
-        return self.datasets["hfb"]
 
-    @property
-    def weight(self) -> memh5.MemDataset:
-        """The inverse variance weight dataset."""
-        return self["hfb_weight"]
-
-    @property
-    def nsample(self) -> memh5.MemDataset:
-        """The number of non-zero samples."""
-        return self.datasets["nsample"]
-
-
-class HFBHighResSpectrum(FreqContainer):
+class HFBHighResSpectrum(HFBContainer):
     """Container for holding high-resolution frequency spectrum"""
 
     _dataset_spec = {
@@ -345,7 +307,7 @@ class HFBHighResSpectrum(FreqContainer):
             "initialise": True,
             "distributed": False,
         },
-        "hfb_weight": {
+        "weight": {
             "axes": ["freq"],
             "dtype": np.float32,
             "initialise": True,
@@ -358,18 +320,3 @@ class HFBHighResSpectrum(FreqContainer):
             "distributed": False,
         },
     }
-
-    @property
-    def hfb(self) -> memh5.MemDataset:
-        """The main hfb dataset."""
-        return self.datasets["hfb"]
-
-    @property
-    def weight(self) -> memh5.MemDataset:
-        """The inverse variance weight dataset."""
-        return self["hfb_weight"]
-
-    @property
-    def nsample(self) -> memh5.MemDataset:
-        """The number of non-zero samples."""
-        return self.datasets["nsample"]

--- a/ch_pipeline/hfb/containers.py
+++ b/ch_pipeline/hfb/containers.py
@@ -23,8 +23,11 @@ class HFBContainer(ContainerBase):
 
     @property
     def hfb(self) -> memh5.MemDataset:
-        """The main hfb dataset."""
-        return self.datasets["hfb"]
+        """Convenience access to the main hfb dataset."""
+        if "hfb" in self.datasets:
+            return self.datasets["hfb"]
+        else:
+            raise KeyError("Dataset 'hfb' not initialised.")
 
     @property
     def weight(self) -> memh5.MemDataset:
@@ -33,14 +36,19 @@ class HFBContainer(ContainerBase):
             weight = self["weight"]
         elif "hfb_weight" in self:
             weight = self["hfb_weight"]
-        else:
+        elif "flags" in self and "hfb_weight" in self["flags"]:
             weight = self["flags/hfb_weight"]
+        else:
+            raise KeyError("Cannot find weight dataset.")
         return weight
 
     @property
     def nsample(self) -> memh5.MemDataset:
-        """The number of non-zero samples."""
-        return self.datasets["nsample"]
+        """Get the nsample dataset (number of non-zero samples) if it exists."""
+        if "nsample" in self.datasets:
+            return self.datasets["nsample"]
+        else:
+            raise KeyError("Dataset 'nsample' not initialised.")
 
 
 class HFBData(RawContainer, FreqContainer, HFBContainer):


### PR DESCRIPTION
PR #200 should be handled before this one.

I gathered the properties that were repeated for all HFB containers (except the `HFBRFIMask` one) into a new base HFB container class called `HFBContainer`. There was some inconsistency in the naming of the weights dataset between different containers. I tried to handle this, but wasn't sure if the existing names had a purpose or if some functionality could break because of my changes.

All HFB containers so far were subclasses of `core.containers.FreqContainer`, so I made `HFBContainer` a subclass of `FreqContainer`. However, HFB data does not necessarily need to have a frequency axis (although its primary purpose requires keeping a frequency axis). Perhaps at some point we want to make a container for light curves, integrated over frequency, or something like that. In that case, it would make more sense to make `HFBContainer` a subclass of `core.containers.ContainerBase`, and keep the current HFB container classes explicitly a subclass of `FreqContainer` (as well as a subclass of the new `HFBContainer`). What do you think?