### PR TITLE
fix(hfb): remove redistribute in `HFBStackDays`

### DIFF
--- a/ch_pipeline/hfb/analysis.py
+++ b/ch_pipeline/hfb/analysis.py
@@ -391,7 +391,7 @@ class HFBStackDays(task.SingleTask):
 
             # For uniform weighting, simply normalize accumulated data by number
             # of days to finalize stack.hfb.
-            self.stack.hfb[:] /= norm
+            self.stack.hfb[:] *= tools.invert_no_zero(norm)
 
         else:
             # For inverse variance weighting, the weight dataset doesn't have to

--- a/ch_pipeline/hfb/analysis.py
+++ b/ch_pipeline/hfb/analysis.py
@@ -330,8 +330,6 @@ class HFBStackDays(task.SingleTask):
                 self.stack.add_dataset("nsample")
                 self.stack.nsample[:] = 0
 
-            self.stack.redistribute("freq")
-
             self.lsd_list = []
 
         # Accumulate


### PR DESCRIPTION
There was a `redistribute` statement that was superfluous, I think. Without it, the task to also work for `HFBHighResRingMap`