### PR TITLE
HFB add beam container

### DIFF
--- a/ch_pipeline/hfb/containers.py
+++ b/ch_pipeline/hfb/containers.py
@@ -1,6 +1,7 @@
 """HFB containers
 """
 
+from caput.cache import cached_property
 from typing import Union
 
 import numpy as np
@@ -65,12 +66,12 @@ class HFBBeamContainer(HFBContainer):
         """The beam indices associated with each entry of the beam axis."""
         return self.index_map["beam"]
 
-    @property
+    @cached_property
     def beam_ew(self):
         """The unique EW-beam indices (i.e., from 0 to 3) in the beam axis."""
         return np.unique(self.beam // 256)
 
-    @property
+    @cached_property
     def beam_ns(self):
         """The unique NS-beam indices (i.e., from 0 to 256) in the beam axis."""
         return np.unique(self.beam % 256)

--- a/ch_pipeline/hfb/containers.py
+++ b/ch_pipeline/hfb/containers.py
@@ -62,17 +62,17 @@ class HFBBeamContainer(HFBContainer):
     _axes = ("beam",)
 
     @property
-    def beam(self):
+    def beam(self) -> np.ndarray:
         """The beam indices associated with each entry of the beam axis."""
         return self.index_map["beam"]
 
     @cached_property
-    def beam_ew(self):
+    def beam_ew(self) -> np.ndarray:
         """The unique EW-beam indices (i.e., from 0 to 3) in the beam axis."""
         return np.unique(self.beam // 256)
 
     @cached_property
-    def beam_ns(self):
+    def beam_ns(self) -> np.ndarray:
         """The unique NS-beam indices (i.e., from 0 to 256) in the beam axis."""
         return np.unique(self.beam % 256)
 
@@ -376,28 +376,32 @@ class HFBRingMapBase(SiderealContainer, HFBContainer):
     _axes = ("beam_ew", "beam_ns", "el")
 
     @property
-    def beam_ew(self):
+    def beam_ew(self) -> np.ndarray:
         """The (unique) EW beam indices (i.e., from 0 to 3) of the beam_ew axis."""
         return self.index_map["beam_ew"]
 
     @property
-    def beam_ns(self):
+    def beam_ns(self) -> np.ndarray:
         """The (unique) NS beam indices (i.e., from 0 to 256) of the beam_ns axis."""
         return self.index_map["beam_ns"]
 
     @property
-    def el(self):
+    def el(self) -> np.ndarray:
         """The el = sin(zenith angle) associated with each sample of the el axis.
+
         The zenith angle used is the reference angle for the NS beam in question.
         The true el of a data sample can be computed from the NS beam index and
-        the sample's frequency using the synthetic beam model."""
+        the sample's frequency using the synthetic beam model.
+        """
         return self.index_map["el"]
 
     @property
-    def ra(self):
-        """The RA in degrees associated with each sample of the RA axis. This is
-        valid for EW beam index 1. For other EW beams, there is an offset in RA
-        that depends on the EW and NS beam index."""
+    def ra(self) -> np.ndarray:
+        """The RA in degrees associated with each sample of the RA axis.
+
+        This is valid for EW beam index 1. For other EW beams, there is an
+        offset in RA that depends on the EW and NS beam index.
+        """
         return self.index_map["ra"]
 
 

--- a/ch_pipeline/hfb/containers.py
+++ b/ch_pipeline/hfb/containers.py
@@ -68,30 +68,12 @@ class HFBBeamContainer(HFBContainer):
     @property
     def beam_ew(self):
         """The unique EW-beam indices (i.e., from 0 to 3) in the beam axis."""
-        return self.get_beam_ew()
+        return np.unique(self.beam // 256)
 
     @property
     def beam_ns(self):
         """The unique NS-beam indices (i.e., from 0 to 256) in the beam axis."""
-        return self.get_beam_ns()
-
-    def get_beam_ew(self, return_inverse=False):
-        """Find the unique EW-beam indices (i.e., from 0 to 3) in the beam axis.
-
-        If called with `return_inverse=True`, return a tuple of (a) unique EW-beam
-        indices and (b) an array mapping each sample in the beam axis to an index
-        in the output array of unique EW-beam indices.
-        """
-        return np.unique(self.beam // 256, return_inverse=return_inverse)
-
-    def get_beam_ns(self, return_inverse=False):
-        """Find the unique NS-beam indices (i.e., from 0 to 256) in the beam axis.
-
-        If called with `return_inverse=True`, return a tuple of (a) unique NS-beam
-        indices and (b) an array mapping each sample in the beam axis to an index
-        in the output array of unique NS-beam indices.
-        """
-        return np.unique(self.beam % 256, return_inverse=return_inverse)
+        return np.unique(self.beam % 256)
 
 
 class HFBData(RawContainer, FreqContainer, HFBBeamContainer):

--- a/ch_pipeline/hfb/containers.py
+++ b/ch_pipeline/hfb/containers.py
@@ -73,7 +73,7 @@ class HFBBeamContainer(HFBContainer):
 
     @cached_property
     def beam_ns(self) -> np.ndarray:
-        """The unique NS-beam indices (i.e., from 0 to 256) in the beam axis."""
+        """The unique NS-beam indices (i.e., from 0 to 255) in the beam axis."""
         return np.unique(self.beam % 256)
 
 

--- a/ch_pipeline/hfb/containers.py
+++ b/ch_pipeline/hfb/containers.py
@@ -341,13 +341,34 @@ class HFBHighResSpectrum(HFBHighResContainer):
 
 
 class HFBRingMapBase(SiderealContainer, HFBContainer):
-    """Base class for HFB ringmaps."""
+    """Base class for HFB ringmaps.
 
-    _axes = ("beam_ew", "el")
+    These containers include axes to mark the EW and NS beam indices, as well as
+    RA (inherited from :class:`SiderealContainer`) and el = sin(zenith angle) axes.
+
+    The el axis corresponds to the sin(za) of the reference angles for the NS beams.
+    The true el for a given bit of data also depends on the frequency and can be
+    computed from the NS beam index and frequency using the synthetic beam model.
+    """
+
+    _axes = ("beam_ew", "beam_ns", "el")
+
+    @property
+    def beam_ew(self):
+        """The (unique) EW beam indices (i.e., from 0 to 3) of the beam_ew axis."""
+        return self.index_map["beam_ew"]
+
+    @property
+    def beam_ns(self):
+        """The (unique) NS beam indices (i.e., from 0 to 256) of the beam_ns axis."""
+        return self.index_map["beam_ns"]
 
     @property
     def el(self):
-        """The elevation in degrees associated with each sample of the elevation axis."""
+        """The el = sin(zenith angle) associated with each sample of the el axis.
+        The zenith angle used is the reference angle for the NS beam in question.
+        The true el of a data sample can be computed from the NS beam index and
+        the sample's frequency using the synthetic beam model."""
         return self.index_map["el"]
 
 
@@ -385,7 +406,7 @@ class HFBHighResRingMap(HFBRingMapBase, HFBHighResContainer):
     """Container for holding high-resolution frequency ringmap data.
 
     With respect to :class:`HFBRingMap`, the (combined) frequency axis is moved
-    to the back, and the distributed axis is changed to the elevation axis.
+    to the back, and the distributed axis is changed to the el = sin(za) axis.
     This is because further downstream in the pipeline, we will look for features
     along the frequency axis.
     """

--- a/ch_pipeline/hfb/containers.py
+++ b/ch_pipeline/hfb/containers.py
@@ -371,6 +371,13 @@ class HFBRingMapBase(SiderealContainer, HFBContainer):
         the sample's frequency using the synthetic beam model."""
         return self.index_map["el"]
 
+    @property
+    def ra(self):
+        """The RA in degrees associated with each sample of the RA axis. This is
+        valid for EW beam index 1. For other EW beams, there is an offset in RA
+        that depends on the EW and NS beam index."""
+        return self.index_map["ra"]
+
 
 class HFBRingMap(FreqContainer, HFBRingMapBase):
     """Container for holding HFB ringmap data."""

--- a/ch_pipeline/hfb/containers.py
+++ b/ch_pipeline/hfb/containers.py
@@ -343,7 +343,7 @@ class HFBHighResSpectrum(HFBHighResContainer):
 class HFBRingMapBase(SiderealContainer, HFBContainer):
     """Base class for HFB ringmaps."""
 
-    _axes = ("beam", "el")
+    _axes = ("beam_ew", "el")
 
     @property
     def el(self):
@@ -358,21 +358,21 @@ class HFBRingMap(FreqContainer, HFBRingMapBase):
 
     _dataset_spec = {
         "hfb": {
-            "axes": ["freq", "subfreq", "beam", "el", "ra"],
+            "axes": ["freq", "subfreq", "beam_ew", "el", "ra"],
             "dtype": np.float32,
             "initialise": True,
             "distributed": True,
             "distributed_axis": "freq",
         },
         "weight": {
-            "axes": ["freq", "subfreq", "beam", "el", "ra"],
+            "axes": ["freq", "subfreq", "beam_ew", "el", "ra"],
             "dtype": np.float32,
             "initialise": True,
             "distributed": True,
             "distributed_axis": "freq",
         },
         "nsample": {
-            "axes": ["freq", "subfreq", "beam", "el", "ra"],
+            "axes": ["freq", "subfreq", "beam_ew", "el", "ra"],
             "dtype": np.uint16,
             "initialise": False,
             "distributed": True,
@@ -392,21 +392,21 @@ class HFBHighResRingMap(HFBRingMapBase, HFBHighResContainer):
 
     _dataset_spec = {
         "hfb": {
-            "axes": ["beam", "el", "ra", "freq"],
+            "axes": ["beam_ew", "el", "ra", "freq"],
             "dtype": np.float32,
             "initialise": True,
             "distributed": True,
             "distributed_axis": "el",
         },
         "weight": {
-            "axes": ["beam", "el", "ra", "freq"],
+            "axes": ["beam_ew", "el", "ra", "freq"],
             "dtype": np.float32,
             "initialise": True,
             "distributed": True,
             "distributed_axis": "el",
         },
         "nsample": {
-            "axes": ["beam", "el", "ra", "freq"],
+            "axes": ["beam_ew", "el", "ra", "freq"],
             "dtype": np.uint16,
             "initialise": False,
             "distributed": True,
@@ -420,14 +420,14 @@ class HFBSearchResult(HFBRingMapBase, HFBHighResContainer):
 
     _dataset_spec = {
         "max_snr": {
-            "axes": ["beam", "el", "ra", "freq"],
+            "axes": ["beam_ew", "el", "ra", "freq"],
             "dtype": np.float32,
             "initialise": True,
             "distributed": True,
             "distributed_axis": "el",
         },
         "best_width": {
-            "axes": ["beam", "el", "ra", "freq"],
+            "axes": ["beam_ew", "el", "ra", "freq"],
             "dtype": np.float32,
             "initialise": True,
             "distributed": True,


### PR DESCRIPTION
Make a base class `HFBBeamContainer` for all HFB containers that have
that have a `beam` axis. This also has `beam_ew` and `beam_ns`

I think this code could be looked at already, ~~but merging may need to wait for PR #210 to be merged~~

Note to self: ~~after PR #210 is handled, but~~ before merging this PR, check if any changes still need to be added in `hfb/analysis.py` from commit 21a267c8 that could otherwise get lost