### PR TITLE
Exclude NaNs in weather data when interpolating

### DIFF
--- a/ch_pipeline/analysis/calibration.py
+++ b/ch_pipeline/analysis/calibration.py
@@ -1899,6 +1899,11 @@ class ThermalCalibration(task.SingleTask):
         )
         wtime, wtemp = self._load_weather(trng)
 
+        # Exclude NaNs and Infs in weather data from the interpolation
+        weather_sel = np.isfinite(wtemp)
+        wtime = wtime[weather_sel]
+        wtemp = wtemp[weather_sel]
+
         # Gain corrections for direct gains (no interpolation).
         #######################################################
         # Reference temperatures


### PR DESCRIPTION
There are occasionally NaN values in the raw weather data, which get mixed into the gains with interpolation. ~15 days have failed for this reason. This fix just excludes any NaNs or Infs from the weather data before interpolating