### PR TITLE
Change doc requirements to allow Sphinx version 5.0

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
-Sphinx >= 5.0, <7.0
+Sphinx
 sphinx_rtd_theme
-docutils >=0.18.1, <0.20
+docutils

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
-Sphinx >= 4.0, <= 5.0
+Sphinx >= 5.0, <7.0
 sphinx_rtd_theme
 docutils==0.17

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
 Sphinx >= 5.0, <7.0
 sphinx_rtd_theme
-docutils==0.17
+docutils >=0.18.1, <0.20

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
-Sphinx >= 4.0, < 5.0
+Sphinx >= 4.0, <= 5.0
 sphinx_rtd_theme
 docutils==0.17


### PR DESCRIPTION
I ran into the following error when trying to merge PR #218:
```
Sphinx version error:
The sphinx_rtd_theme extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
Error: Process completed with exit code 2.
```

The present PR allows Sphinx version 5.0

@tristpinsm do you remember the reason for excluding this version (as per your PR #100, over a year ago)?

I tested this by installing Sphinx 5.0.0 and sphinx-rtd-theme 2.0.0 and running the following from inside the main ch_pipeline directory: `sphinx-build -W -b html doc/ doc/_build/html`
That seemed to work without issues