### PR TITLE
Daily Pipeline rev_08 Config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,8 +47,8 @@ jobs:
         pip install future
         pip install numpy
         pip install cython
-        pip install --use-deprecated=legacy-resolver -r requirements.txt
-        pip install --use-deprecated=legacy-resolver -r doc/requirements.txt
+        pip install --use-deprecated=legacy-resolver -r requirements.txt --no-binary bitshuffle
+        pip install --use-deprecated=legacy-resolver -r doc/requirements.txt --no-binary bitshuffle
 
     - name: Install ch_pipeline
       run: pip install -e .

--- a/ch_pipeline/analysis/flagging.py
+++ b/ch_pipeline/analysis/flagging.py
@@ -2542,7 +2542,7 @@ def compute_cumulative_rainfall(
 
     # Load rainfall measurements within relevant time range
     rain_timestamps, rain_meas = load_rainfall(
-        times[0] - accumulation_time_s * 3600 - _TIME_BUFFER,
+        times[0] - accumulation_time_s - _TIME_BUFFER,
         times[-1] + _TIME_BUFFER,
         node_spoof,
     )
@@ -2569,6 +2569,13 @@ def compute_cumulative_rainfall(
     # that occurs after this time. This errs on the side of potentially
     # overestimating the cumulative rainfall at a given input time.
     time_timestamp_idx = np.searchsorted(rain_timestamps, times, side="left")
+    # If the rightmost value(s) of `times` are greater than `rain_timestamps`,
+    # `searchsorted` returns the last index + 1, which is out of bounds.
+    # If this is the case, assume that the last available rainfall value
+    # extends to times with no data
+    time_timestamp_idx[time_timestamp_idx >= len(rain_timestamps)] = (
+        len(rain_timestamps) - 1
+    )
     cumu_rainfall = cumu_rainfall[time_timestamp_idx]
 
     return cumu_rainfall

--- a/ch_pipeline/analysis/flagging.py
+++ b/ch_pipeline/analysis/flagging.py
@@ -147,6 +147,14 @@ class RFIStokesIMask(dflagging.RFIStokesIMask):
 
     This has a static mask for the local environment and will use the MAD
     algorithm (over SumThreshold) when bright sources are visible.
+
+    Attributes
+    ----------
+    transit_width : float, optional
+        Ignore any times that occur within this number of sigma from
+        the transit of a bright source.  Here sigma refers to the standard
+        deviation of a a Gaussian approximation to the primary beam.
+        Default is 2.0.
     """
 
     transit_width = config.Property(proptype=float, default=2.0)
@@ -198,6 +206,23 @@ class RFIStokesIMask(dflagging.RFIStokesIMask):
         mask |= daytime_flag(times)
 
         return mask
+
+    def _solar_transit_hook(self, times):
+        """Override to flag solar transit times.
+
+        Parameters
+        ----------
+        times : np.ndarray[float]
+            Array of timestamps.
+
+        Returns
+        -------
+        mask : np.ndarray[float]
+            Mask array. True will mask out a time sample.
+        """
+        sun = ephemeris.skyfield_wrapper.ephemeris["sun"]
+
+        return transit_flag(sun, times, nsigma=self.transit_width)
 
 
 class RFIMaskChisqHighDelay(dflagging.RFIMaskChisqHighDelay):

--- a/ch_pipeline/processing/client.py
+++ b/ch_pipeline/processing/client.py
@@ -266,7 +266,7 @@ def generate(
 @item.command("update")
 @click.argument("revision", type=PREV)
 @click.option(
-    "--clean",
+    "--clear",
     is_flag=True,
     help="Remove data files which are no longer needed by this revision.",
 )
@@ -278,6 +278,7 @@ def generate(
 def update_files(revision, clear, retrieve):
     """Manage files between project and long-term storage spaces."""
     nfiles = revision.update_files(retrieve=retrieve, clear=clear)
+
     if retrieve:
         click.echo(f"Retrieving {nfiles['nretrieve']} files.")
     if clear:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ ch_util @ git+https://github.com/chime-experiment/ch_util.git
 cora @ git+https://github.com/radiocosmology/cora.git
 driftscan @ git+https://github.com/radiocosmology/driftscan.git
 draco @ git+https://github.com/radiocosmology/draco.git
+numpy<2
 pytz
 apscheduler


### PR DESCRIPTION
# Updated RFI masking
- Uses the new `RFIStokesIMask` task, with significant improvements to RFI flagging
- Adds RFI flagging based on a high-delay chi-squared metric
- Adds RFI flagging based on sensitivity metric

# Sidereal rebinning
Uses the new `SiderealRebinner` task in place of regridding, which is significantly simpler than the previous regridding task and eliminates the artifacts introduced at this stage. Also removes the `ThresholdVisWeightBaseline` task which was required to remove regridding artifacts.

The rebinning process results in a difference between the true and effective RA bin centres, so a correction is required. On the daily level, a local gradient is calculated based on a stack dataset with full sidereal and frequency coverage. This correction will be applied _after_ stacking when producing a stack from this data.

# Restrict run order for `BeamFormCat` tasks
Slightly modifies the run order around `BeamFormCat` tasks. This task can store a large copy of the sidereal stream data in its `setup` method, so these changes try to (a) block the setup from happening until `next` can run right afterwards and (b) restrict the number of outputs based on the number of catalogs being loaded so that the task moves to its `finish` state as soon as the last iteration is done. 

# Fixes and improvements to file online/offline management
Properly manage weather files, flag checks, and file pad lag.

# Dependencies
- [x] radiocosmology/caput#258 to implement priority and output limits
- [x] radiocosmology/caout#255 and #215 to fix a potential bug when loading modules
- [x] #226 to fix a NaN bug in some weather data
- [x] #239 to implement automatic online/nearline file management and additional data checks
- [x] radiocosmology/draco#265 and #241 to implement the new RFI mask
- [x] radiocosmology/draco#269 to implement the new rebinning feature
- [x] radiocosmology/draco#260 to fix a bug with dataset axis selections
- [x] radiocosmology/draco#271 to implement multi-output saving for tasks and minor RFI fixes
- [x] radiocosmology/draco#274 to implement improved sensitivity-based RFI masking
- [x] radiocosmology/draco#262 to implement max-likelihood delay power spectrum estimator and fixes to Gibbs delay power spectrum estimator
- [x] radiocosmology/draco#275 for residual bug fixes
- [x] https://github.com/chime-experiment/Daily_validation/pull/24 for final validation notebook changes
- [x] https://github.com/chime-experiment/cedar-environment/pull/6 for file clear automation
- [x] https://github.com/radiocosmology/draco/pull/280 tweak to flagging and blending