### PR TITLE
Add a task to establish a database connection

### DIFF
--- a/ch_pipeline/core/dataquery.py
+++ b/ch_pipeline/core/dataquery.py
@@ -65,6 +65,35 @@ def _force_list(val) -> list:
         return [val]
 
 
+class ConnectDatabase(task.MPILoggedTask):
+    """Establish an initial connection to the chimedb database.
+
+    This is useful when running pipelines on machines with poor
+    network I/O.
+
+    Attributes
+    ----------
+    timeout : int
+        Connection timeout in seconds
+    ntries : int
+        Number of times to retry if connection fails
+    """
+
+    timeout = config.Property(proptype=int, default=5)
+    ntries = config.Property(proptype=int, default=5)
+
+    def setup(self):
+        """Establish a database connection"""
+
+        import chimedb.core
+
+        # Set the os connection timeout variable
+        os.environ["CHIMEDB_CONNECT_TIMEOUT"] = str(self.timeout)
+
+        # Try to establish a connection
+        chimedb.core.connect(ntries=self.ntries)
+
+
 class QueryDatabase(task.MPILoggedTask):
     """Find files from specified database queries.
 

--- a/ch_pipeline/processing/daily.py
+++ b/ch_pipeline/processing/daily.py
@@ -59,6 +59,11 @@ pipeline:
       params:
         timeout: 420
 
+    - type: ch_pipeline.core.dataquery.ConnectDatabase
+      params:
+        timeout: 5
+        ntries: 5
+
     # Query for all the data for the sidereal day we are processing
     - type: ch_pipeline.core.dataquery.QueryDatabase
       out: filelist

--- a/ch_pipeline/processing/daily.py
+++ b/ch_pipeline/processing/daily.py
@@ -68,7 +68,6 @@ pipeline:
         accept_all_global_flags: true
         node_spoof:
           cedar_online: "/project/rpp-chime/chime/chime_online/"
-        connection_attempts: 5
         instrument: chimestack
 
     # Load the telescope model that we need for several steps


### PR DESCRIPTION
There have been a lot of issues with failed connections to chimedb from cedar recently. This PR adds a task to establish an initial connection with the database given some configurable timeout and number of attempts.

Depends on chime-experiment/chimedb#42 and chime-experiment/ch_util#69