### PR TITLE
fix(hfb.containers): Add width axis and amplitude dataset to `HFBSearchResult`

### DIFF
--- a/ch_pipeline/hfb/containers.py
+++ b/ch_pipeline/hfb/containers.py
@@ -546,16 +546,11 @@ class HFBHighResBeamAvgRingMap(HFBRingMapBase, HFBHighResContainer):
 class HFBSearchResult(HFBRingMapBase, HFBHighResContainer):
     """Container for holding results of blind search."""
 
+    _axes = ("width",)
+
     _dataset_spec = {
-        "max_snr": {
-            "axes": ["beam_ew", "el", "ra", "freq"],
-            "dtype": np.float32,
-            "initialise": True,
-            "distributed": True,
-            "distributed_axis": "el",
-        },
-        "best_width": {
-            "axes": ["beam_ew", "el", "ra", "freq"],
+        "ln_lambda": {
+            "axes": ["width", "beam_ew", "el", "ra", "freq"],
             "dtype": np.float32,
             "initialise": True,
             "distributed": True,
@@ -564,11 +559,6 @@ class HFBSearchResult(HFBRingMapBase, HFBHighResContainer):
     }
 
     @property
-    def max_snr(self):
-        """Get the dataset of maximum SNR over template widths."""
-        return self.datasets["max_snr"]
-
-    @property
-    def best_width(self):
-        """Get the dataset of the template width corresponding to the maximum SNR."""
-        return self.datasets["best_width"]
+    def ln_lambda(self):
+        """The log-likelihood-ratio dataset."""
+        return self.datasets["ln_lambda"]

--- a/ch_pipeline/hfb/containers.py
+++ b/ch_pipeline/hfb/containers.py
@@ -556,9 +556,21 @@ class HFBSearchResult(HFBRingMapBase, HFBHighResContainer):
             "distributed": True,
             "distributed_axis": "el",
         },
+        "amplitude": {
+            "axes": ["width", "beam_ew", "el", "ra", "freq"],
+            "dtype": np.float32,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "el",
+        },
     }
 
     @property
     def ln_lambda(self):
         """The log-likelihood-ratio dataset."""
         return self.datasets["ln_lambda"]
+
+    @property
+    def amplitude(self):
+        """The absorption-feature-amplitude dataset."""
+        return self.datasets["amplitude"]


### PR DESCRIPTION
Added an axis for the trial widths of the absorption features that we search for.
- The axis is called `width`, hopefully that understandable enough.
- I put this at the front of the axis order.
- I left the `el` axis to be the distributed axis, since we may not search over more widths than we use nodes in a given run.