### PR TITLE
fix(hfb.analysis): make SelectBeam a pipeline task

### DIFF
--- a/ch_pipeline/hfb/analysis.py
+++ b/ch_pipeline/hfb/analysis.py
@@ -915,7 +915,7 @@ class HFBSelectTransit(task.SingleTask):
         return out
 
 
-class SelectBeam(BeamSelectionMixin):
+class SelectBeam(BeamSelectionMixin, task.SingleTask):
     """Select a subset of EW and/or NS beams from a container.
 
     The selection is made by passing `beam_ew_include` and/or `beam_ns_index` or


### PR DESCRIPTION
`SelectBeam` needs to subclass a pipeline task class, such as `task.SingleTask`

Otherwise, running the pipeline gives the following error:
```
AttributeError: type object 'SelectBeam' has no attribute '_from_config'
```