### PR TITLE
fix(hfb.analysis): fix _interpolation_linear wrap mode

### DIFF
--- a/ch_pipeline/hfb/analysis.py
+++ b/ch_pipeline/hfb/analysis.py
@@ -1317,9 +1317,9 @@ def _interpolation_linear(x, y, w, xeval, mode="zero", xperiod=None):
         # For points below and above the range of x, overwrite the interval,
         # adjusting for the period
         if below.size > 0:
-            adx1[below] = xeval - x[ind1] - xperiod
+            adx1[below] = xeval[below] - x[-1] - xperiod
         if above.size > 0:
-            adx2[above] = x[ind2] + xperiod - xeval
+            adx2[above] = x[0] + xperiod - xeval[above]
 
     # Compute relative weights of left and right points
     norm = tools.invert_no_zero(adx1 + adx2)


### PR DESCRIPTION
This should fix the bug that gave this error:
```
ValueError                                Traceback (most recent call last)
/tmp/ipykernel_1004435/21639821.py in <module>
     17             data_shifted[iewb, insb, :, :],
     18             weight_shifted[iewb, insb, :, :],
---> 19         ) = _interpolation_linear(
     20                     x=ra_shifted,
     21                     y=on_off[iewb, insb, :, :],

/project/6003614/arashm/new_chimeenv/code/ch_pipeline/ch_pipeline/hfb/analysis.py in _interpolation_linear(x, y, w, xeval, mode, xperiod)
   1318         # adjusting for the period
   1319         if below.size > 0:
-> 1320             adx1[below] = xeval - x[ind1] - xperiod
   1321         if above.size > 0:
   1322             adx2[above] = x[ind2] + xperiod - xeval

ValueError: shape mismatch: value array of shape (4280,) could not be broadcast to indexing result of shape (7,)
```