### PR TITLE
fix(hfb.io): make selections in file loader more robust

### DIFF
--- a/ch_pipeline/hfb/io.py
+++ b/ch_pipeline/hfb/io.py
@@ -293,9 +293,9 @@ class BaseLoadFiles(BeamSelectionMixin, io.BaseLoadFiles):
             cont = rd.read()
         else:
             kwargs = {}
-            if self.freq_sel:
+            if self.freq_sel is not None:
                 kwargs["freq_sel"] = self.freq_sel
-            if self.beam_sel:
+            if self.beam_sel is not None:
                 kwargs["beam_sel"] = self.beam_sel
 
             cont = HFBData.from_file(files[0], distributed=self.distributed, **kwargs)


### PR DESCRIPTION
Fixes a bug that gave this problem while loading files:
```
  File "/home/lieshout/chime/code/ch_pipeline/ch_pipeline/hfb/io.py", line 372, in process
    ts = self._load_filelist(filegroup["files"], time_range)
  File "/home/lieshout/chime/code/ch_pipeline/ch_pipeline/hfb/io.py", line 306, in _load_filelist
    if self.beam_sel:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```