### PR TITLE
fix(base): improve re match on db connection error

### DIFF
--- a/ch_pipeline/processing/base.py
+++ b/ch_pipeline/processing/base.py
@@ -442,13 +442,9 @@ class ProcessingType(object):
                 re.compile(r"ValueError(.*?)infs(.*?)NaNs"),
             ],
             # Find out of memory errors
-            "out_of_memory": [
-                re.compile(r"numpy.core._exceptions._ArrayMemoryError(.*?)MPI_ABORT")
-            ],
+            "out_of_memory": [re.compile(r"numpy.core._exceptions._ArrayMemoryError")],
             # Error connecting to chimedb database
-            "chimedb_error": [
-                re.compile(r"chimedb.core.exceptions.ConnectionError(.*?)MPI_ABORT")
-            ],
+            "chimedb_error": [re.compile(r"chimedb.core.exceptions.ConnectionError")],
             # Find crashes due to job timeout
             "time_limit": [
                 re.compile(r"slurmstepd: error:(.*?)CANCELLED(.*?)TIME LIMIT"),

--- a/ch_pipeline/processing/base.py
+++ b/ch_pipeline/processing/base.py
@@ -629,16 +629,21 @@ def classify_failed(
         if not file.is_file():
             continue
         # Get the end of the file. Assume an average of 100 characters
-        # per line, so get around 300 lines.
+        # per line.
         with open(file, "rb") as f:
             try:
                 f.seek(-300 * 100, os.SEEK_END)
             except OSError:
+                # Assume that this is just a small log file, so read
+                # the entire thing
+                pass
+
+            try:
+                tail = f.read().decode()
+            except OSError:
                 # There was an issue reading the log file, so just assume
                 # that there's nothing there and classify this tag accordingly
                 tail = " "
-            else:
-                tail = f.read().decode()
 
         # See if any of the patterns that we are looking for
         # exist in the stdout


### PR DESCRIPTION
This is a fix that I intend to hot patch for the new pipeline runner. If a job failed very early, `f.seek` would not be able to return ~300 lines and would instead throw `OSError` and the cause of failure could not be determined. Also, the regex matches were not working with `MPI_ABORT` at the end, and it isn't really needed, so I removed it.

Note that this doesn't have to be done _immediately_, as it just affects the pipelines ability to re-queue jobs which have crashed