### PR TITLE
Include slurm files in failed job check

### DIFF
--- a/ch_pipeline/processing/daily.py
+++ b/ch_pipeline/processing/daily.py
@@ -1014,6 +1014,11 @@ class DailyProcessing(base.ProcessingType):
                 *rev_stats["failed"],
             }
             all_tags = [tag for tag in all_tags if tag not in exclude_tags]
+            # Prioritize recent days to ensure that data is available
+            today = np.floor(ephemeris.chime.get_current_lsd()).astype(int)
+            all_tags = [
+                tag for tag in all_tags if (today - int(tag)) <= self._num_recent_days
+            ]
             # Search the next 20 tags and request any that we may want to be brought online.
             online_request_tags = sorted(
                 [int(tag) for tag in all_tags[:20] if tag not in upcoming]


### PR DESCRIPTION
Normally, the full log output is written to the `jobout.log` file. Occasionally, when a job fails because it reaches its time limit, the slurm message ("Job cancelled due to timeout") gets written to the slurm output file instead. Annoyingly, this doesn't seem to happen consistently. 

This change will check both the standard jobout file *and* the slurm output file.

Also, ensure that recent days are checked first in the `update_files` method of the daily processing. *NOTE*: this will have to be deployed if `auto-copy-to-online` script is removed @ketiltrout 