### PR TITLE
Correctly include older days in --retrieve list

### DIFF
--- a/ch_pipeline/processing/daily.py
+++ b/ch_pipeline/processing/daily.py
@@ -1016,9 +1016,10 @@ class DailyProcessing(base.ProcessingType):
             all_tags = [tag for tag in all_tags if tag not in exclude_tags]
             # Prioritize recent days to ensure that data is available
             today = np.floor(ephemeris.chime.get_current_lsd()).astype(int)
-            all_tags = [
+            priority = [
                 tag for tag in all_tags if (today - int(tag)) <= self._num_recent_days
             ]
+            all_tags = priority + [tag for tag in all_tags if tag not in priority]
             # Search the next 20 tags and request any that we may want to be brought online.
             online_request_tags = sorted(
                 [int(tag) for tag in all_tags[:20] if tag not in upcoming]


### PR DESCRIPTION
With the last change I made, the pipeline would _only_ recall data for CSDS in the past week, which isn't what we want