### PR TITLE
Fix import extra processing types

### DIFF
--- a/ch_pipeline/processing/client.py
+++ b/ch_pipeline/processing/client.py
@@ -2,7 +2,7 @@
 
 import click
 
-from . import base
+from . import base, beam, daily, quarterstack  # noqa: F401
 
 click.disable_unicode_literals_warning = True
 


### PR DESCRIPTION
These got automatically removed when adding ruff, since ruff doesn't like unused imports. However, they're actually needed to resolve the available processing types for `chp`.