### PR TITLE
Check for tags which do not have data available anywhere

### DIFF
--- a/ch_pipeline/processing/base.py
+++ b/ch_pipeline/processing/base.py
@@ -337,7 +337,7 @@ class ProcessingType:
         return []
 
     @property
-    def _all_tags(self) -> list:
+    def _config_tags(self) -> list:
         """Return the list of tags requested by the config."""
         return []
 
@@ -558,7 +558,7 @@ class ProcessingType:
         return {
             "available": available_tags,
             "not_available": [
-                tag for tag in self._all_tags if str(tag) not in available_tags
+                tag for tag in self._config_tags if str(tag) not in available_tags
             ],
             "not_yet_submitted": not_submitted_tags,
             "pending": pending_tags,


### PR DESCRIPTION
The part of the pipeline that checks for files to retrieve just looked at all the tags in the config and tried to fetch the upcoming ones that aren't online. The problem is that it didn't check to see if the tags it was trying to retrieve actually had _any_ data available anywhere, so it eventually gets stuck trying to request the same days over and over again, which will never end up online because there aren't any files.

This fix lets the pipeline first check whether a CSD has the minimum amount of data needed to run _anywhere_, not just on cedar_online.