### PR TITLE
fix(beam): properly re-center HA grid after unwrapping long transits

### DIFF
--- a/ch_pipeline/analysis/beam.py
+++ b/ch_pipeline/analysis/beam.py
@@ -1278,9 +1278,9 @@ def unwrap_lha(lsa, src_ra):
     lsa += start_lsa
     # subtract source RA
     return np.where(
-        np.abs(lsa - src_ra) < np.abs(lsa - src_ra + 360.0),
+        np.abs(lsa - src_ra) < np.abs(lsa - (src_ra + 360.0)),
         lsa - src_ra,
-        lsa - src_ra + 360.0,
+        lsa - src_ra - 360.0,
     )
 
 


### PR DESCRIPTION
Fixes an issue where the HA coordinate of very long transits (~180 degrees) would not be properly re-centered about HA=0, causing the holography regridder (`ch_pipeline.analysis.beam.TransitRegridder`) to silently fail, returning a stream of 0s in the output. See the attached plot for an example of the old and new behavior for a long transit of Tau A (RA ~ 83) which wraps at 360 degrees. 

![image](https://github.com/user-attachments/assets/fe139d34-f201-48ae-9945-6a63f09b1c34)
