### PR TITLE
Ar/offline telescope

### DIFF
--- a/ch_pipeline/core/telescope.py
+++ b/ch_pipeline/core/telescope.py
@@ -238,9 +238,9 @@ class CHIME(telescope.PolarisedTelescope):
             layout_path = files("ch_pipeline/core/telescope_files/layouts.pkl")
 
             with layout_path.open("rb") as layout_f:
-                layouts = np.array(pickle.load(layout_f))
+                layouts = pickle.load(layout_f)
 
-            # Get the layout that was in use at the requested time
+            # Load layout start and end times in arrays for comparisons
             lay_start = np.array([lay["start"] for lay in layouts])
             lay_end = np.array([lay["end"] for lay in layouts])
 
@@ -274,11 +274,11 @@ class CHIME(telescope.PolarisedTelescope):
                 # The last 'end' element is None, change it to today
                 lay_end[-1] = datetime.datetime.today()
 
-                lay_in_use = layouts[
-                    (self.layout > lay_start) & (self.layout < lay_end)
-                ][0]
+                lay_in_use = np.where(
+                        (self.layout > lay_start) & (self.layout < lay_end)
+                )[0][0]
 
-                feeds = lay_in_use["inputs"]
+                feeds = layouts[lay_in_use]["inputs"]
 
         else:
             feeds = None

--- a/ch_pipeline/core/telescope.py
+++ b/ch_pipeline/core/telescope.py
@@ -234,8 +234,9 @@ class CHIME(telescope.PolarisedTelescope):
 
             # Get the path of the layout file
             from importlib.resources import files
+            from . import telescope_files
 
-            layout_path = files("ch_pipeline/core/telescope_files/layouts.pkl")
+            layout_path = files(telescope_files).joinpath("layouts.pkl")
 
             with layout_path.open("rb") as layout_f:
                 layouts = pickle.load(layout_f)
@@ -275,7 +276,7 @@ class CHIME(telescope.PolarisedTelescope):
                 lay_end[-1] = datetime.datetime.today()
 
                 lay_in_use = np.where(
-                        (self.layout > lay_start) & (self.layout < lay_end)
+                    (self.layout > lay_start) & (self.layout < lay_end)
                 )[0][0]
 
                 feeds = layouts[lay_in_use]["inputs"]

--- a/ch_pipeline/core/telescope.py
+++ b/ch_pipeline/core/telescope.py
@@ -276,7 +276,7 @@ class CHIME(telescope.PolarisedTelescope):
                 lay_end[-1] = datetime.datetime.today()
 
                 lay_in_use = np.where(
-                    (self.layout > lay_start) & (self.layout < lay_end)
+                    (self.layout >= lay_start) & (self.layout <= lay_end)
                 )[0][0]
 
                 feeds = layouts[lay_in_use]["inputs"]
@@ -290,9 +290,14 @@ class CHIME(telescope.PolarisedTelescope):
         # Override base method to implement automatic loading of layout when
         # configuring from YAML.
 
-        if self.layout is not None:
-            logger.debug("Loading layout: %s", str(self.layout))
-            self._load_layout()
+        if self.layout is None:
+            logger.warning(
+                "You have not set the layout attribute of the telescope "
+                "in your config file. The layout will be set to today."
+            )
+            self.layout = datetime.datetime.today()
+        logger.debug("Loading layout: %s", str(self.layout))
+        self._load_layout()
 
         # Set the overall normalization of the beam
         self._set_beam_normalization()

--- a/ch_pipeline/core/telescope.py
+++ b/ch_pipeline/core/telescope.py
@@ -252,7 +252,7 @@ class CHIME(telescope.PolarisedTelescope):
                     "You have requested a layout from before the earliest "
                     "recorded layout. Will attempt to query the "
                     "database. To avoid this behavior, select a layout "
-                    "after September 1, 2018."
+                    f"after {lay_start[0].strftime('%B %d, %Y')}."
                 )
 
                 feeds = tools.get_correlator_inputs(self.layout, self.correlator)
@@ -261,10 +261,10 @@ class CHIME(telescope.PolarisedTelescope):
             elif self.layout > lay_start[-1]:
                 logger.warning(
                     "You have requested the latest locally recorded layout, "
-                    "from October 13, 2020. There is no guarantee that this "
-                    "is the latest layout available from the database. "
-                    "Attempt a database connection if you are certain you "
-                    "need the latest available layout."
+                    f"from {lay_start[-1].strftime('%B %d, %Y')}. There is "
+                    "no guarantee this is the latest layout available from "
+                    "the database. Attempt a database connection if you are "
+                    "certain you need the latest available layout."
                 )
 
                 feeds = layouts[-1]["inputs"]

--- a/ch_pipeline/core/telescope.py
+++ b/ch_pipeline/core/telescope.py
@@ -5,12 +5,11 @@ configuration db (:mod:`~ch_analysis.pathfinder.configdb`) for the details of
 the feeds and their positions.
 """
 
+import datetime
 import logging
+import pickle
 from functools import cached_property
 from typing import ClassVar
-import pickle
-import datetime
-
 
 import healpy
 import numpy as np
@@ -234,6 +233,7 @@ class CHIME(telescope.PolarisedTelescope):
 
             # Get the path of the layout file
             from importlib.resources import files
+
             from . import telescope_files
 
             layout_path = files(telescope_files).joinpath("layouts.pkl")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ chp = "ch_pipeline.processing.client:cli"
 [tool.setuptools.dynamic]
 readme = {file = ["README.md"], content-type = "text/markdown"}
 
+[tool.setuptools.package-data]
+"ch_pipeline.core.telescope_files" = ["layouts.pkl"]
+
 [tool.setuptools-git-versioning]
 enabled = true
 


### PR DESCRIPTION
This PR adds functionality to `ch_pipeline.core.telescope.CHIME` which allows the feed layout of a `CHIME` instance to be obtained from a file saved to this repository, circumventing the usual database query. 

Reading from the file is now the default behavior; this can be overridden and a database query used by setting `read_local_layout: False` when configuring from YAML in a pipeline job, or passing `read_local_layout=False` to `CHIME.from_layout` in an interactive setting.  