### PR TITLE
refactor(analysis): Use `object_coords` Observer method

### DIFF
--- a/ch_pipeline/analysis/beam.py
+++ b/ch_pipeline/analysis/beam.py
@@ -7,7 +7,7 @@ import numpy as np
 from caput import config, mpiarray, mpiutil, tod
 from caput.pipeline import PipelineRuntimeError
 from caput.time import STELLAR_S, unix_to_datetime
-from ch_ephem import coord, sources
+from ch_ephem import sources
 from ch_ephem.observers import chime
 from ch_util import holography, tools
 from chimedb.core import connect as connect_database
@@ -184,9 +184,7 @@ class TransitGrouper(task.SingleTask):
                 ts = tod.concatenate(self.tstreams, start=start_ind, stop=stop_ind)
             else:
                 ts = self.tstreams[0]
-            _, dec = coord.object_coords(
-                self.src, all_t[0], deg=True, obs=self.observer
-            )
+            _, dec = self.observer.object_coords(self.src, all_t[0], deg=True)
             ts.attrs["dec"] = dec
             ts.attrs["source_name"] = self.source
             ts.attrs["transit_time"] = self.cur_transit
@@ -307,9 +305,9 @@ class TransitRegridder(Regridder):
         vis_data = data.vis[:].view(np.ndarray)
 
         # Get apparent source RA, including precession effects
-        ra, _ = coord.object_coords(self.src, data.time[0], deg=True, obs=self.observer)
+        ra, _ = self.observer.object_coords(self.src, data.time[0], deg=True)
         # Get catalogue RA for reference
-        ra_icrs, _ = coord.object_coords(self.src, deg=True, obs=self.observer)
+        ra_icrs, _ = self.observer.object_coords(self.src, deg=True)
 
         # Convert input times to hour angle
         lha = unwrap_lha(self.observer.unix_to_lsa(data.time), ra)

--- a/ch_pipeline/analysis/calibration.py
+++ b/ch_pipeline/analysis/calibration.py
@@ -630,7 +630,7 @@ class EigenCalibration(task.SingleTask):
         ttrans = chime.transit_times(source_obj.skyfield, data.time[0])[0]
         csd = int(np.floor(chime.unix_to_lsd(ttrans)))
 
-        src_ra, src_dec = coord.object_coords(
+        src_ra, src_dec = chime.object_coords(
             source_obj.skyfield, date=ttrans, deg=True
         )
 
@@ -998,7 +998,7 @@ class TransitFit(task.SingleTask):
         source_obj = sources.source_dictionary[response.attrs["source_name"]]
         ttrans = response.attrs["transit_time"]
 
-        src_ra, src_dec = coord.object_coords(source_obj, date=ttrans, deg=True)
+        src_ra, src_dec = chime.object_coords(source_obj, date=ttrans, deg=True)
 
         ha = response.ra[:] - src_ra
         ha = ((ha + 180.0) % 360.0) - 180.0
@@ -3786,7 +3786,7 @@ class CorrectTimeOffset(CalibrationCorrection):
         # Determine location of calibrator
         ttrans = chime.transit_times(body, timestamp[0] - 24.0 * 3600.0)[0]
 
-        ra, dec = coord.object_coords(body, date=ttrans, deg=False)
+        ra, dec = chime.object_coords(body, date=ttrans, deg=False)
 
         ha = np.radians(chime.unix_to_lsa(ttrans + time_offset)) - ra
 
@@ -3843,7 +3843,7 @@ class CorrectTelescopeRotation(CalibrationCorrection):
         # Determine location of calibrator
         ttrans = chime.transit_times(body, timestamp[0] - 24.0 * 3600.0)[0]
 
-        ra, dec = coord.object_coords(body, date=ttrans, deg=False)
+        ra, dec = chime.object_coords(body, date=ttrans, deg=False)
 
         # Calculate and return the phase correction, which is old positions minus new positions
         # since we previously divided the chimestack data by the response to the calibrator.


### PR DESCRIPTION
This all still works as-is, but since Seth ported this function to `caput` as an `Observer` method (https://github.com/radiocosmology/caput/pull/290), let's use that directly.