### PR TITLE
Switch deprecated 'np.issubclass_' to 'issubclass'

### DIFF
--- a/ch_pipeline/core/telescope.py
+++ b/ch_pipeline/core/telescope.py
@@ -918,10 +918,10 @@ class CHIMEExternalBeam(CHIME):
             ]
 
             complex_beam = np.all(
-                [np.issubclass_(hpbt, np.complexfloating) for hpbt in hpb_types]
+                [issubclass(hpbt, np.complexfloating) for hpbt in hpb_types]
             )
         else:
-            complex_beam = np.issubclass_(
+            complex_beam = issubclass(
                 self._primary_beam.beam.dtype.type, np.complexfloating
             )
 


### PR DESCRIPTION
This is deprecated in numpy 2.0, and there's no reason to continue to use it anyway