### PR TITLE
feat(flagging): support for tapering maps around the location of sources

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -129,3 +129,8 @@ authors:
 - given-names: "Alex"
   family-names: "Reda"
   affiliation: "Yale University"
+
+- given-names: "Yukari"
+  family-names: "Uchibori"
+  affiliation: "University of British Columbia"
+  orcid: "https://orcid.org/0009-0003-4114-1301"

--- a/ch_pipeline/analysis/flagging.py
+++ b/ch_pipeline/analysis/flagging.py
@@ -3038,7 +3038,7 @@ class SourceTracksMixin(SourcePixelsMixin):
 
         valid = np.nonzero(flag)
 
-        return src_ind[valid[0]], data.ra[valid[1]], src_dec[valid[0]], y[valid]
+        return src_ind[valid[0]], ra[valid[1]], src_dec[valid[0]], y[valid]
 
 
 class MaskFromCatalogBase(CatalogBase):

--- a/ch_pipeline/analysis/flagging.py
+++ b/ch_pipeline/analysis/flagging.py
@@ -2893,7 +2893,7 @@ class CatalogBase(task.SingleTask):
 
         if "frequency" in self.catalog:
             src_freq = self.catalog["frequency"]["freq"][:]
-            src_freq_err = self.catalog["frequency"]["freq_err"][:]
+            src_freq_err = self.catalog["frequency"]["freq_error"][:]
 
         else:
             z = self.catalog["redshift"]["z"][:]

--- a/ch_pipeline/core/telescope.py
+++ b/ch_pipeline/core/telescope.py
@@ -153,6 +153,7 @@ class CHIME(telescope.PolarisedTelescope):
         self.latitude = chime.latitude
         self.longitude = chime.longitude
         self.altitude = chime.altitude
+        self.skyfield = chime.skyfield
 
         # Set the LSD start epoch (i.e. CHIME/Pathfinder first light)
         self.lsd_start_day = datetime.datetime(2013, 11, 15)


### PR DESCRIPTION
* Refactor catalog-based masking code.
* Create TaperSourcePixelsFromCatalog and TaperSourceTracksFromCatalog,
which generate a smooth transition from 1 to 0 around the location
of bright soruces.
* Add ability to mask a subset of frequencies based on source redshift.
* Add support for a user-specified horizon limit.