### PR TITLE
feat(hfb): update from HFBDirectionalRFIMask to HFBDirectionalRFIMaskBitmap

### DIFF
--- a/ch_pipeline/hfb/containers.py
+++ b/ch_pipeline/hfb/containers.py
@@ -575,49 +575,105 @@ class HFBSearchResult(HFBRingMapBase, HFBHighResContainer):
         return self.datasets["amplitude"]
 
 
-class HFBDirectionalRFIMask(FreqContainer, TODContainer):
-    """Container for an RFI mask based on HFB data.
+class HFBDirectionalRFIMaskBitmap(FreqContainer, TODContainer):
+    """Container for HFB directional RFI masks.
 
-    This RFI mask takes advantage of the high-frequency resolution of HFB data.
-    It can also store the fraction of subfrequency channels (out of 128)
-    that detected RFI events.
-
+    Each 32-bit unsigned integer stores four separate 8-bit data segments,
+    corresponding to the number of HFB subfrequency channels detecting RFI
+    under different values of estimated standard deviation used for detection.
     """
 
     _axes = ("beam_ns",)
 
     _dataset_spec: ClassVar = {
-        "mask": {
+        "subfreq_rfi": {
             "axes": ["freq", "beam_ns", "time"],
-            "dtype": bool,
+            "dtype": np.uint32,
             "initialise": True,
-            "distributed": True,
-            "distributed_axis": "freq",
-        },
-        "frac_rfi": {
-            "axes": ["freq", "beam_ns", "time"],
-            "dtype": np.float32,
-            "initialise": False,
             "distributed": True,
             "distributed_axis": "freq",
             "compression": COMPRESSION,
             "compression_opts": COMPRESSION_OPTS,
             "chunks": (64, 128, 512),
-            "truncate": True,
+            "truncate": False,
         },
     }
 
-    @property
-    def mask(self):
-        """Return the north-south beam-dependent mask."""
-        return self.datasets["mask"]
+    def __init__(self, *args, std_key: list[float] = [], **kwargs):
+        """Sets up the bitmap attribute in the packed 32-bit representation."""
+        super().__init__(*args, **kwargs)
+
+        # If std_key was provided, add it to attrs
+        if std_key:
+            if len(std_key) != 4:
+                raise ValueError(
+                    "Exactly four std values must be provided for packing into 32 bits."
+                )
+        self.attrs["bitmap"] = {std: i for i, std in enumerate(std_key)}
 
     @property
-    def frac_rfi(self):
-        """Return the north-south beam-dependent rfi frac dataset."""
-        return self.datasets["frac_rfi"]
+    def bitmap(self):
+        """Return the bitmap."""
+        return self.attrs["bitmap"]
 
     @property
     def beam_ns(self):
         """Return the north-south beam index map."""
         return self.index_map["beam_ns"]
+
+    @property
+    def subfreq_rfi(self):
+        """Return the packed 32-bit unsigned integer subfrequency RFI masks."""
+        return self.datasets["subfreq_rfi"]
+
+    @property
+    def mask(self):
+        """Disables the property for this container."""
+        raise AttributeError(
+            "The 'mask' property is not available in HFBDirectionalRFIMaskBitmap. "
+            "Use 'get_mask(std_key, subfreq_threshold)' to extract a specific 8-bit mask."
+        )
+
+    @property
+    def frac_rfi(self):
+        """Disables the property for this container."""
+        raise AttributeError(
+            "The 'frac_rfi' property is not available in HFBDirectionalRFIMaskBitmap. "
+            "Use 'get_frac_rfi(std_type)' to extract a specific 8-bit mask."
+        )
+
+    def get_subfreq_rfi(self, std_key: float) -> np.ndarray:
+        """Extract the 8-bit RFI data for a given beam type."""
+        offset = self.bitmap.get(std_key)
+        if offset is None:
+            raise ValueError(
+                f"Invalid std_key '{std_key}'. Must be one of {list(self.bitmap.keys())}."
+            )
+        return ((self.subfreq_rfi[:] >> (8 * offset)) & 0xFF).astype(np.uint8)
+
+    def set_subfreq_rfi(self, std_key: float, values: np.ndarray) -> None:
+        """Set the 8-bit RFI data for a given beam type."""
+        if not self.attrs["bitmap"]:
+            raise ValueError("bitmap is not set yet.")
+
+        offset = self.bitmap.get(std_key)
+
+        if offset is None:
+            raise ValueError(
+                f"Invalid std_key '{std_key}'. Must be one of {list(self.bitmap.keys())}."
+            )
+        if np.any((values < 0) | (values > 128)):
+            raise ValueError("Values must be in range 0 to 128.")
+
+        # Clear the target byte
+        self.subfreq_rfi[:] &= np.uint32(~(0xFF << (8 * offset)) & 0xFFFFFFFF)
+        # Set the new values in the correct byte position
+        self.subfreq_rfi[:] |= (values.astype(np.uint32) & 0xFF) << (8 * offset)
+
+    def get_mask(self, std_key: float, subfreq_threshold: int) -> np.ndarray:
+        """Get a boolean RFI mask for a given std value and subfrequency RFI threshold."""
+        return self.get_subfreq_rfi(std_key) >= subfreq_threshold
+
+    def get_frac_rfi(self, std_key: float) -> np.ndarray:
+        """Get the fraction of HFB subfrequency channels detecting RFI for a given std value."""
+        return self.get_subfreq_rfi(std_key) / 128

--- a/ch_pipeline/hfb/flagging.py
+++ b/ch_pipeline/hfb/flagging.py
@@ -3,10 +3,13 @@
 import beam_model.formed as fm
 import numpy as np
 from caput import config, tools
+from draco.analysis.sidereal import _search_nearest
 from draco.core import task
 from draco.core.containers import LocalizedRFIMask
+from mpi4py import MPI
+from scipy.spatial.distance import cdist
 
-from .containers import HFBDirectionalRFIMask, HFBRFIMask
+from .containers import HFBDirectionalRFIMaskBitmap, HFBRFIMask
 
 
 class HFBRadiometerRFIFlagging(task.SingleTask):
@@ -127,33 +130,29 @@ class ApplyHFBMask(task.SingleTask):
 class HFBDirectionalRFIFlagging(task.SingleTask):
     """Produce a RFI mask based on HFB sensitivity values.
 
-    The mask is for each N-S beam positions averaged over every E-W beam positions
-    and for each chime frequency channel averaged over every 128 HFB subfrequencies.
-    This task assumes that the loaded HFBData contains a rectangular selection of beams,
-    i.e., nbeam_ew x nbeam_ns = nbeam.
+    This task detects RFI signals based on deviations from expected radiometer noise
+    in the second East-West beams (beam IDs: 256-512) for multiple values of std.
+    It produces a directional RFI mask container recording the number of HFB subfrequency
+    channels flagged for RFI under each std.
 
     Attributes
     ----------
-    std : float
-        The estimated standard deviation of the Gaussian modeling the distribution
-        of HFB sensitivity values. Default is 0.15.
-    threshold : float
-        This is to detect RFI in HFB sensitivity values. If it exceeds 1 + treshold * std,
-        then it indicates RFI events. Default is 5.
-    threshold_subfreq : int
-        Flag out a CHIME frequency channel if the number of its subfrequency channels detecting
-        RFI is above this value. Default is 1.
-    keep_frac_rfi : bool
-         Save the fraction of subfrequency channels detecting RFI events.
+    beam_ew_id : int
+        The E-W beam index to inspect for RFI detection. Default is 1. (beam IDs: 256-512)
+    std : list of float
+        List of std values used for the RFI detection thresholds. Each will result in a separate mask.
+        Default is [0.25, 0.275, 0.30, 0.325].
+    sigma_threshold : float
+        This is to detect RFI in HFB sensitivity values. If it exceeds
+        1 + treshold * std (or std_avg), then it indicates RFI events. Default is 5.
     """
 
-    std = config.Property(proptype=float, default=0.15)
-    threshold = config.Property(proptype=float, default=5)
-    threshold_subfreq = config.Property(proptype=int, default=1)
-    keep_frac_rfi = config.Property(proptype=bool, default=False)
+    beam_ew_id = config.Property(proptype=int, default=1)
+    std = config.Property(proptype=list, default=[0.25, 0.275, 0.30, 0.325])
+    sigma_threshold = config.Property(proptype=float, default=5)
 
     def process(self, stream):
-        """Produce a RFI mask.
+        """Produce a directional RFI mask from HFB data.
 
         Parameters
         ----------
@@ -162,13 +161,10 @@ class HFBDirectionalRFIFlagging(task.SingleTask):
 
         Returns
         -------
-        out : containers.HFBDirectionalRFIMask
-            Boolean mask that can be converted to a draco container `LocalizedRFIMask`
-            with the task `HFBMaskConversion` to mask contaminated
-            frequencies, beam/el, and time samples.
-
+        out : containers.HFBDirectionalRFIMaskBitmap
+            Container holding the RFI masks across different std values.
         """
-        # Get the dimensions of the data array
+        # Get dimensions from the HFB data
         nfreq, nsubfreq, nbeam, ntime = stream.hfb[:].shape
         nbeam_ew = len(stream.beam_ew)
         nbeam_ns = len(stream.beam_ns)
@@ -176,156 +172,186 @@ class HFBDirectionalRFIFlagging(task.SingleTask):
         # Radiometer noise test: the sensitivity metric would be unity for
         # an ideal radiometer, it would be higher for data with RFI
         sensitivities = sensitivity_metric(stream=stream, average_beams=False)
-
-        # Averaging over E-W beams
         sensitivities = sensitivities.reshape(
             nfreq, nsubfreq, nbeam_ew, nbeam_ns, ntime
+        )[
+            :, :, self.beam_ew_id, :, :
+        ]  # (nfreq, nsubfreq, nbeam_ns, ntime)
+
+        # Create output container with the same axes
+        out = HFBDirectionalRFIMaskBitmap(
+            std_key=self.std,
+            freq=stream.freq[:],
+            beam_ns=stream.beam_ns[:],
+            time=stream.time[:],
         )
-        sensitivities = np.mean(sensitivities, axis=2)
+        out.attrs["bitmap"] = {std: i for i, std in enumerate(self.std[:])}
 
-        # Detecting RFI
-        count = sensitivities > 1.0 + self.threshold * self.std
-        count = np.sum(count, axis=1)
-        mask = count > self.threshold_subfreq
+        # For each std, compute RFI flags and store counts
+        for i in range(len(self.std)):
 
-        # Extract axis arrays
-        freq = stream.freq[:]
-        time = stream.time[:]
-        beam_ns = stream.beam_ns[:]
+            # RFI detection for individual E-W beams
+            flags = sensitivities > 1.0 + self.sigma_threshold * self.std[i]
 
-        # Create container to hold output
-        out = HFBDirectionalRFIMask(beam_ns=beam_ns, freq=freq, time=time)
+            # Summing over subfrequency channels
+            count = np.sum(flags, axis=1)
 
-        # Save mask to output container
-        out.mask[:] = mask
-
-        if self.keep_frac_rfi:
-            out.add_dataset("frac_rfi")
-            out.frac_rfi[:] = count / nsubfreq
+            # Store counts into appropriate directional masks
+            out.set_subfreq_rfi(self.std[i], count)
 
         # Return output container
         return out
 
 
-class HFBMaskConversion(task.SingleTask):
-    """Convert axes from beam_ns to el.
+class RFIMaskHFBRegridderNearest(task.SingleTask):
+    """Convert HFBDirectionalRFIMaskBitmap axis from beam_ns to el.
 
-    Note that before CSD = 3685, the time axes were not synchronized between cosmology and HFB data.
+    This task takes an HFBDirectionalRFIMaskBitmap, selects the RFI mask corresponding
+    to a specific std value used in the detection, then regrids the mask from
+    the beam_ns axis to an el axis.
+
+    Notes
+    -----
+    - Before CSD 3685, the time axes of HFB and cosmology data were not synchronized.
 
     Attributes
     ----------
-    spread_size : int
-        The number of cells to flag before and after a detected true value. This ensures
-        conservative flagging, preventing missed detections due to axis alignment issues.
-        Default is 1.
+    std : float
+        Must match one of the std keys used when the HFBDirectionalRFIMaskBitmap was
+        created. Default is 0.25.
+    subfreq_threshold : int
+        Subfrequency threshold for decoding the bitmap. A sample is flagged if
+        the number of HFB subfrequency channels detecting RFI >= this threshold.
+        Default is 2.
+    keep_frac_rfi : bool
+        Save the fraction of HFB subfrequency channels (Out of 128) detecting RFI
+        that were used to construct the mask, storing this as an additional dataset
+        in the output container. Default is False.
+    spread_factor : float
+        Spreading factor for conservative flagging. Each flagged mask sample is
+        expanded to neighboring target el values within
+        'spread_factor x resolution' of the axis. Default is 1.0.
     npix : int
-        The number of pixels used to cover the full el range from -1 to 1.
-         Defualt is 512.
+        The number of pixels used to cover the full elevation range from -1 to 1.
+        Default is 512.
     """
 
-    spread_size = config.Property(proptype=int, default=1)
+    std = config.Property(proptype=float, default=0.25)
+    subfreq_threshold = config.Property(proptype=int, default=2)
+    keep_frac_rfi = config.Property(proptype=bool, default=False)
+    spread_factor = config.Property(proptype=float, default=1)
     npix = config.Property(proptype=int, default=512)
 
-    def process(self, rfimask):
-        """Produce a RFI mask.
+    def process(self, rfimaskbitmap):
+        """Convert beam_ns axis of an HFBDIrectionalRFIMaskBitmap to el axis.
 
         Parameters
         ----------
-        rfimask : containers.HFBDirectionalRFIMask
-            RFI mask whose axes are freq, beam_ns, and time.
+        rfimaskbitmap : containers.HFBDirectionalRFIMaskBitmap
+            Input RFI mask with axes (freq, beam_ns, time).
 
         Returns
         -------
         out : containers.LocalizedRFIMask
-            Boolean mask that can be converted to a draco container `LocalizedSiderealRFIMask`
-            with the task `SiderealMaskConversion` to mask contaminated
-            frequencies, el, and time/ra samples.
+            Converted mask with axes (freq, el, time).
         """
-        # Extract mask/frac and axes data
-        mask = rfimask.mask[:]
-        freq = rfimask.freq[:]
-        time = rfimask.time[:]
-        beam_ns = rfimask.beam_ns[:]
+        # Ensure data is distributed in frequency
+        rfimaskbitmap.redistribute("freq")
 
-        nfreq, nbeam_ns, ntime = mask.shape
-
-        # Convert beam IDs to el values
+        # Convert beam_ns indices to elevation angles (sin(theta))
         v = fm.FFTFormedBeamModel()
-        angles = v.get_beam_positions(beam_ns, freq)
-        el = np.sin(np.deg2rad(angles.T[1]))
+        angles = v.get_beam_positions(rfimaskbitmap.beam_ns[:], rfimaskbitmap.freq[:])
+        el = np.sin(np.deg2rad(angles.T[1]))  # shape (freq, beam_ns)
 
-        # Find closest el indices
-        full_el = np.linspace(-1, 1, self.npix)
-        el_closest_indices = np.abs(el[:, :, None] - full_el).argmin(axis=2)
+        # Create new elevation axis, restricting to overlapping region with original beams
+        to_ax = np.linspace(-1, 1, self.npix)
+        start = _search_nearest(to_ax, np.min(el))
+        end = _search_nearest(to_ax, np.max(el))
+        valid_range = slice(start, end + 1)
+        new_ax = to_ax[valid_range]
 
-        # Make the new el axis
-        min_index = np.min(el_closest_indices)
-        max_index = np.max(el_closest_indices)
-        new_el = full_el[min_index : max_index + 1]
-        nel = len(new_el)
-
-        ax = list(rfimask.mask.attrs["axis"]).index("freq")
-        nfreq_local = rfimask.mask.local_shape[ax]
-        sf = rfimask.mask.local_offset[ax]
-        ef = sf + nfreq_local
-
-        # Generate meshgrid indices for the freq and el axes
-        n0, _, n2 = np.meshgrid(
-            np.arange(nfreq_local) + sf,
-            np.arange(nbeam_ns),
-            np.arange(ntime),
-            indexing="ij",
+        # Create output container with the new axes
+        out = LocalizedRFIMask(
+            freq=rfimaskbitmap.freq[:], el=new_ax, time=rfimaskbitmap.time[:]
         )
-        el_closest_indices = el_closest_indices - np.min(el_closest_indices)
-
-        # Generate meshgrid indices for the freq and el axes
-        n0, _, n2 = np.meshgrid(
-            np.arange(nfreq), np.arange(nbeam_ns), np.arange(ntime), indexing="ij"
-        )
-        el_closest_indices = el_closest_indices - np.min(el_closest_indices)
-
-        # Broadcast indices along the last axis
-        index_tuple = (n0, el_closest_indices[sf:ef, :, None], n2)
-
-        # Broadcast the mask data
-        mask_adj = np.full((nfreq, nel, ntime), False)
-        mask_adj[index_tuple] = mask
-
-        # Falg before and after a given true value for conservative flagging
-        for repeat in range(self.spread_size):
-            mask_adj[:, :-1, :] |= mask_adj[:, 1:, :]
-            mask_adj[:, 1:, :] |= mask_adj[:, :-1, :]
-            mask_adj[:, :-2, :] |= mask_adj[:, 2:, :]
-            mask_adj[:, 2:, :] |= mask_adj[:, :-2, :]
-
-        # Create container to hold output
-        out = LocalizedRFIMask(freq=freq, el=new_el, time=time)
-
-        # Save the adjusted mask to output container
-        out.mask[:] = mask_adj
-
-        # If the input container has the frac_rfi dataset
-        if rfimask.datasets.get("frac_rfi", None) is not None:
-            frac_rfi = rfimask.frac_rfi[:]
-            frac_rfi_adj = np.full((nfreq, nel, ntime), 0.0)
-            frac_rfi_adj[index_tuple] = frac_rfi
-
-            for repeat in range(self.spread_size):
-                frac_rfi_adj[:, :-1, :] = np.maximum(
-                    frac_rfi_adj[:, :-1, :], frac_rfi_adj[:, 1:, :]
-                )
-                frac_rfi_adj[:, 1:, :] = np.maximum(
-                    frac_rfi_adj[:, 1:, :], frac_rfi_adj[:, :-1, :]
-                )
-                frac_rfi_adj[:, :-2, :] = np.maximum(
-                    frac_rfi_adj[:, :-2, :], frac_rfi_adj[:, 2:, :]
-                )
-                frac_rfi_adj[:, 2:, :] = np.maximum(
-                    frac_rfi_adj[:, 2:, :], frac_rfi_adj[:, :-2, :]
-                )
-
+        if self.keep_frac_rfi:
             out.add_dataset("frac_rfi")
-            out.frac_rfi[:] = frac_rfi_adj
+
+        # Determine local frequency slice for this MPI rank
+        freq_ax = list(rfimaskbitmap.subfreq_rfi.attrs["axis"]).index("freq")
+        nfreq_local = rfimaskbitmap.subfreq_rfi[:].local_array.shape[freq_ax]
+        max_freq = self.comm.allreduce(nfreq_local, op=MPI.MAX)
+        sf = rfimaskbitmap.subfreq_rfi.local_offset[freq_ax]
+        ef = sf + max_freq + 1
+
+        # Process each frequency separately since beam-to-el mapping varies with freq
+        for f in range(sf, ef):
+
+            # To avoid issues occurring when the last iteration of frequency-distributed data processing
+            # is pending, particularly to handle the case of an empty slice at the end.
+            i = f
+            if (i - sf) >= nfreq_local:
+                i = sf
+
+            # Extract mask for this std and threshold
+            mask = rfimaskbitmap.get_mask(self.std, self.subfreq_threshold)[
+                :
+            ].local_array[i - sf]
+
+            # Optionally carry over the number of HFB subrequency channels detecting RFI
+            if self.keep_frac_rfi:
+                frac_rfi = rfimaskbitmap.get_frac_rfi(self.std)[:].local_array[i - sf]
+
+            # Locate slice in new elevation axis
+            el_start = _search_nearest(new_ax, out.el[0])
+            el_end = _search_nearest(new_ax, out.el[-1]) + 1
+
+            # Estimate resolutions to determine mapping strategy
+            from_ax = el[i, :]
+            new_resolution = np.median(np.abs(np.diff(new_ax)))
+            from_resolution = np.median(np.abs(np.diff(from_ax)))
+
+            # Determine nearest-neighbor indices for mapping
+            if new_resolution < from_resolution:
+                nearest_indices = _search_nearest(from_ax, new_ax)
+            else:
+                nearest_indices = np.arange(len(from_ax))
+
+            # Compute pairwise distances between each new axis point and nearest from_ax points
+            dist = cdist(
+                new_ax[:, np.newaxis],
+                from_ax[nearest_indices, np.newaxis],
+                metric="euclidean",
+            )
+
+            # Disable spreading if axes align exactly (diagonal distance is zero)
+            if np.all(np.diag(dist) == 0):
+                self.spread_factor = 0
+
+            # Construct conservative spreading window
+            resolution = np.median(np.abs(np.diff(from_ax)))
+            window = np.abs(dist) < self.spread_factor * resolution
+
+            # Interpolate the boolean mask
+            converted = np.tensordot(window, mask[nearest_indices], axes=([1], [0])) > 0
+            out.mask[:].local_array[i - sf, el_start:el_end, :] = converted
+
+            # Interpolate the float frac_rfi
+            if self.keep_frac_rfi:
+                window = window.astype(np.float32)
+                numerator = np.tensordot(
+                    window, frac_rfi[nearest_indices], axes=([1], [0])
+                )
+                denominator = np.sum(window, axis=-1).reshape(
+                    (-1,) + (1,) * (numerator.ndim - 1)
+                )
+                converted = np.divide(
+                    numerator,
+                    denominator,
+                    out=np.zeros_like(numerator),
+                    where=denominator != 0,
+                )
+                out.frac_rfi[:].local_array[i - sf, el_start:el_end, :] = converted
 
         # Return output container
         return out


### PR DESCRIPTION
- Replaced HFBDirectionalRFIMask with HFBDirectionalRFIMaskBitmap
- Updated HFBDirectionalRFIFlagging to generate and store four RFI datasets for different values of threshold in the new container above
- Refactored mask axis conversion tasks (e.g. HFBMaskConversion → HFBMaskRegridderNearest) to operate on HFBDirectionalRFIMaskBitmap