### PR TITLE
feat(hfb): extract per-absorber ringmap cutouts from a catalogue

### DIFF
--- a/ch_pipeline/hfb/analysis.py
+++ b/ch_pipeline/hfb/analysis.py
@@ -1,5 +1,6 @@
 """Tasks for HFB analysis."""
 
+import beam_model.formed as fm
 import numpy as np
 from beam_model.composite import FutureMostAccurateCompositeBeamModel
 from caput import config, mpiarray
@@ -8,9 +9,13 @@ from caput.containers import copy_datasets_filter, empty_like
 from caput.pipeline import tasklib
 from caput.util import mpitools
 from ch_util.hfbcat import HFBCatalog, get_doppler_shifted_freq
+from draco.analysis.sidereal import _search_nearest
+from draco.core import io
 from draco.util import tools
 from skyfield.positionlib import Angle
 from skyfield.starlib import Star
+
+from ch_pipeline.hfb.containers import HFBHighResRingMap
 
 from . import containers
 from .io import BeamSelectionMixin
@@ -954,6 +959,95 @@ class SelectBeam(BeamSelectionMixin, tasklib.base.ContainerTask):
         return newstream
 
 
+class SelectBeamsAroundSources(tasklib.base.ContainerTask):
+    """Select the beams around the sources recorded in the attributes.
+
+    The source declination and frequency are read from the container
+    attributes ('source_dec', 'source_freq'), which are set by
+    LoadFilesForAbsorbers.
+
+    Attributes
+    ----------
+    n_beams_ns : int
+        Number of NS beams to include on either side of the beam closest
+        to each source (i.e. 2 * n_beams_ns + 1 NS beams per source).
+        Default is 2.
+    beam_ew_include : list
+        List of East-West beam indices to include. Default is [0, 1, 2].
+    """
+
+    n_beams_ns = config.Property(proptype=int, default=2)
+    beam_ew_include = config.Property(proptype=list, default=[0, 1, 2])
+
+    def setup(self, manager):
+        """Load the beam model used to locate the sources' NS beams.
+
+        Parameters
+        ----------
+        manager :
+            An Observer object holding the geographic location of the telescope.
+        """
+        self.beam_mdl = fm.FFTFormedBeamModel()
+        self.observer = io.get_telescope(manager)
+        self.latitude = self.observer.latitude
+
+    def process(self, stream):
+        """Select the beams around the catalogue's sources.
+
+        Parameters
+        ----------
+        stream : containers.HFBData
+            Container with a beam axis and 'source_dec' / 'source_freq'
+            attributes.
+
+        Returns
+        -------
+        newstream : containers.HFBData
+            New container holding only the selected beams.
+        """
+        src_dec = np.atleast_1d(stream.attrs["source_dec"])
+        src_freq = np.atleast_1d(stream.attrs["source_freq"])
+
+        # Union of the NS-beam neighbourhoods of all absorbers in the catalogue.
+        ns_beams: set = set()
+        for dec, freq in zip(src_dec, src_freq):
+            angles = self.beam_mdl.get_beam_positions(np.arange(0, 256), [freq])
+            ns0 = int(_search_nearest(angles.T[1][0], dec - self.latitude))
+            ns_beams.update(
+                range(
+                    max(0, ns0 - self.n_beams_ns), min(256, ns0 + self.n_beams_ns + 1)
+                )
+            )
+
+        ns_sel = np.array(sorted(ns_beams))
+        ew_sel = np.array(self.beam_ew_include)
+
+        # Full beam indices, restricted to beams present in the stream
+        beam_sel = (ew_sel[:, np.newaxis] * 256 + ns_sel).flatten()
+        beam_sel = np.sort(beam_sel[np.isin(beam_sel, stream.beam)])
+
+        self.log.info(
+            f"Selecting {beam_sel.size} beams for {src_dec.size} absorbers "
+            f"({ns_sel.size} NS beams, EW {ew_sel.tolist()})."
+        )
+
+        # Create new container with the subset of beams
+        newstream = empty_like(stream, beam=beam_sel)
+
+        # Make sure all datasets are initialised
+        for dname in stream.datasets.keys():
+            if dname not in newstream.datasets:
+                newstream.add_dataset(dname)
+
+        # Find indices in current beam axis of selected subset of beams
+        selindex = np.flatnonzero(np.isin(stream.beam, beam_sel)).tolist()
+
+        # Copy over datasets
+        copy_datasets_filter(stream, newstream, "beam", selindex)
+
+        return newstream
+
+
 class HFBFlattenPFB(tasklib.base.ContainerTask):
     """Flatten HFB data using PFB deconvolution."""
 
@@ -1406,3 +1500,176 @@ class HFBMedianSubtraction(tasklib.base.ContainerTask):
         out.weight[:] = weight
 
         return out
+
+
+class ExtractAbsorberCutouts(tasklib.base.ContainerTask):
+    """Extract and save one cutout per absorber in the catalogue.
+
+    The frequency window is physical (MHz); the RA and el windows are in
+    pixels (samples) around the pixel nearest the source: e.g. the defaults
+    give the centre pixel +/- 30 RA pixels and +/- 1 el pixel (one beam
+    either side). The RA window wraps correctly around RA = 0/360; the el
+    window is clipped at the edges of the el axis.
+
+    Attributes
+    ----------
+    freq_window : float
+        Half-width of the frequency window to extract, in MHz.
+        Default is 0.2 (i.e. a 400 kHz wide cutout, ~131 high-res
+        channels).
+    n_ra : int
+        Number of RA pixels to include on either side of the pixel nearest
+        the source RA (i.e. 2 * n_ra + 1 pixels total). Default is 30.
+    n_el : int
+        Number of el pixels (beams) to include on either side of the pixel
+        nearest the source el (i.e. 2 * n_el + 1 pixels total, clipped at
+        the axis edges). Default is 1.
+    """
+
+    freq_window = config.Property(proptype=float, default=0.2)
+    n_ra = config.Property(proptype=int, default=30)
+    n_el = config.Property(proptype=int, default=1)
+
+    def setup(self, manager):
+        """Set the local observer's position.
+
+        Parameters
+        ----------
+        manager :
+            An Observer object holding the geographic location of the telescope.
+        """
+        self.observer = io.get_telescope(manager)
+        self.latitude = self.observer.latitude
+
+    def process(self, stream):
+        """Extract and save one cutout file per absorber in the catalogue.
+
+        Parameters
+        ----------
+        stream : containers.HFBHighResRingMap
+            High frequency resolution ringmap container.
+
+        Returns
+        -------
+        None
+            Files are saved directly via '_save_output'; nothing is passed
+            downstream.
+        """
+        from mpi4py import MPI
+
+        # Ensure ONLY the freq axis is distributed. After this, beam_ew, el
+        # and ra are complete on every rank.
+        stream.redistribute("freq")
+
+        names = np.atleast_1d(stream.attrs["source_names"])
+        src_ra = np.atleast_1d(stream.attrs["source_ra"])
+        src_dec = np.atleast_1d(stream.attrs["source_dec"])
+        src_freq = np.atleast_1d(stream.attrs["source_freq"])
+        lsd = stream.attrs.get("lsd", stream.attrs.get("csd", None))
+
+        freq = np.asarray(stream.index_map["freq"])
+        ra = np.asarray(stream.index_map["ra"])
+        el = np.asarray(stream.index_map["el"])
+        beam_ns = np.asarray(stream.index_map["beam_ns"])
+        nra = ra.size
+        nel = el.size
+
+        # Local data: (beam_ew, el, ra, freq_local)
+        hfb_local = stream.hfb[:].local_array
+        weight_local = stream.weight[:].local_array
+        freq_offset = stream.hfb[:].local_offset[3]
+        nfreq_local = hfb_local.shape[3]
+        nbeam_ew = hfb_local.shape[0]
+
+        comm = stream.comm
+        nsaved = 0
+
+        for iobj, name in enumerate(names):
+            name = str(name)
+
+            # Frequency: +/- freq_window MHz around the absorber frequency
+            fsel = np.flatnonzero(np.abs(freq - src_freq[iobj]) <= self.freq_window)
+            if fsel.size == 0:
+                self.log.warning(
+                    f"Absorber {name}: no data in frequency range. Skipping."
+                )
+                continue
+
+            # RA: nearest pixel +/- n_ra pixels, wrapping at 0/360
+            dra = (ra - src_ra[iobj] + 180.0) % 360.0 - 180.0
+            ira0 = int(np.argmin(np.abs(dra)))
+            rsel = (ira0 + np.arange(-self.n_ra, self.n_ra + 1)) % nra
+
+            # el: nearest pixel +/- n_el pixels, clipped at edges
+            el_src = np.sin(np.radians(src_dec[iobj] - self.latitude))
+            ie0 = int(np.argmin(np.abs(el - el_src)))
+            esel = np.arange(max(0, ie0 - self.n_el), min(nel, ie0 + self.n_el + 1))
+
+            # Extract this rank's freq chunk
+            shape = (nbeam_ew, esel.size, rsel.size, fsel.size)
+            data_cut = np.zeros(shape, dtype=hfb_local.dtype)
+            weight_cut = np.zeros(shape, dtype=weight_local.dtype)
+
+            # Convert global freq indices to this rank's local indices
+            fsel_local = fsel - freq_offset
+            valid = (fsel_local >= 0) & (fsel_local < nfreq_local)
+            fsel_local = fsel_local[valid]
+
+            # Destination positions along the cutout freq axis (0..nfsel-1)
+            fsel_out = np.flatnonzero(valid)
+
+            if fsel_local.size > 0:
+                ix = np.ix_(np.arange(nbeam_ew), esel, rsel, fsel_local)
+                data_cut[..., fsel_out] = hfb_local[ix]
+                weight_cut[..., fsel_out] = weight_local[ix]
+
+            # Combine freq chunks from all ranks
+            comm.Allreduce(MPI.IN_PLACE, data_cut, op=MPI.SUM)
+            comm.Allreduce(MPI.IN_PLACE, weight_cut, op=MPI.SUM)
+
+            if not weight_cut.any():
+                self.log.warning(f"Absorber {name}: all-zero weights. Skipping.")
+                continue
+
+            # Build and fill the output container
+            out = HFBHighResRingMap(
+                beam_ew=stream.index_map["beam_ew"],
+                beam_ns=beam_ns[esel],
+                el=el[esel],
+                ra=ra[rsel],
+                freq=freq[fsel],
+                attrs_from=stream,
+            )
+            out.redistribute("freq")
+
+            of = out.hfb[:].local_offset[3]
+            ns = out.hfb[:].local_array.shape[3]
+            out.hfb[:].local_array[:] = data_cut[..., of : of + ns]
+            out.weight[:].local_array[:] = weight_cut[..., of : of + ns]
+
+            # Replace catalogue-level array attrs with per-absorber scalars
+            for key in [
+                "source_names",
+                "source_ra",
+                "source_dec",
+                "source_freq",
+                "source_status",
+                "source_amplitude",
+            ]:
+                if key in out.attrs:
+                    del out.attrs[key]
+            out.attrs["source_name"] = name
+            out.attrs["source_ra"] = float(src_ra[iobj])
+            out.attrs["source_dec"] = float(src_dec[iobj])
+            out.attrs["source_freq"] = float(src_freq[iobj])
+
+            tag = name if lsd is None else f"{name}_lsd_{int(lsd)}"
+            out.attrs["tag"] = tag
+
+            outfile = self._save_output(out)
+            if outfile is not None:
+                self.log.info(f"Saved cutout for {name} -> {outfile}.")
+                nsaved += 1
+
+        self.log.info(f"Saved {nsaved}/{len(names)} cutouts.")
+        return

--- a/ch_pipeline/hfb/containers.py
+++ b/ch_pipeline/hfb/containers.py
@@ -1,5 +1,6 @@
 """HFB containers."""
 
+import re
 from functools import cached_property
 from typing import ClassVar
 
@@ -12,6 +13,7 @@ from draco.core.containers import (
     COMPRESSION_OPTS,
     DataWeightContainer,
     SiderealContainer,
+    SourceCatalog,
     TODContainer,
 )
 
@@ -783,3 +785,176 @@ class HFBDirectionalRFIMaskBitmap(FreqContainer, TODContainer):
     def get_frac_rfi(self, sigma_key: float) -> np.ndarray:
         """Get the fraction of HFB subfrequency channels detecting RFI for a given sigma value."""
         return self.get_subfreq_rfi(sigma_key) / 128
+
+
+class AbsorberCatalogue(SourceCatalog):
+    """A catalogue of absorbers (known and candidate).
+
+    Required per-entry values are: 'ra' (degrees), 'dec' (degrees), 'freq' (MHz),
+    and 'status'. The 'amplitude' is optional: when unknown it is stored as
+    NaN, and when provided it must be a finite float.
+
+    Status values
+    -------------
+    Allowed values are "confirmed", "false_positive", "control", and
+    candidates. A candidate records the S/N of its detection in the status
+    itself, e.g. "candidate_snr5" or "candidate_snr7" (plain "candidate" is
+    also allowed if the S/N is unknown). "control" marks bright continuum
+    test sources (e.g. Cyg A) or narrowband RFI used to validate the pipeline.
+    """
+
+    STATUS_VALUES = ("confirmed", "candidate", "false_positive", "control")
+
+    _STATUS_RE = re.compile(
+        r"^(confirmed|false_positive|control|candidate(_snr\d+(\.\d+)?)?)$"
+    )
+
+    _table_spec: ClassVar = {
+        "absorber": {
+            "columns": [
+                ["freq", np.float64],
+                ["amplitude", np.float64],
+                ["status", "<U24"],
+            ],
+            "axis": "object_id",
+        },
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Record the allowed status values in the container attributes
+        self.attrs["status_values"] = list(self.STATUS_VALUES)
+
+    @staticmethod
+    def _snr_of(status) -> float:
+        """S/N recorded in a status ('candidate_snr5' -> 5.0; NaN if none)."""
+        s = str(status)
+        if "_snr" in s:
+            try:
+                return float(s.split("_snr", 1)[1])
+            except ValueError:
+                return np.nan
+        return np.nan
+
+    @classmethod
+    def status_match(cls, status, include) -> np.ndarray:
+        """Boolean mask of 'status' entries matching the 'include' list.
+
+        Rules per entry of 'include':
+        - "confirmed" / "false_positive" : exact match.
+        - "candidate" : matches all candidates.
+        - "candidate_snrX" : matches candidates with S/N >= X
+          (candidates without a recorded S/N are not matched).
+
+        Parameters
+        ----------
+        status : str or array_like of str
+            Status values to test.
+        include : str or list of str
+            Status values to match against.
+
+        Returns
+        -------
+        mask : np.ndarray of bool
+            True for entries that match.
+        """
+        if isinstance(include, str):
+            include = [include]
+
+        status = np.atleast_1d(np.asarray(status, dtype=str))
+        is_candidate = np.char.startswith(status, "candidate")
+        snr = np.array([cls._snr_of(s) for s in status])
+
+        mask = np.zeros(status.size, dtype=bool)
+        for inc in include:
+            inc = str(inc)
+            if inc == "candidate":
+                mask |= is_candidate
+            elif inc.startswith("candidate_snr"):
+                threshold = float(inc.split("_snr", 1)[1])
+                mask |= is_candidate & (snr >= threshold)
+            else:
+                mask |= status == inc
+
+        return mask
+
+    def validate(self):
+        """Check that all entries hold valid values."""
+        names = self.index_map["object_id"]
+
+        # Required columns:
+        ra = self["position"]["ra"][:]
+        dec = self["position"]["dec"][:]
+        freq = self["absorber"]["freq"][:]
+        for field, values, ok in [
+            ("ra", ra, (ra >= 0.0) & (ra <= 360.0)),
+            ("dec", dec, (dec >= -90.0) & (dec <= 90.0)),
+            ("freq", freq, (freq > 0.0) & np.isfinite(freq)),
+        ]:
+            bad = ~ok
+            if bad.any():
+                raise ValueError(
+                    f"Required column '{field}' has missing or out-of-range "
+                    f"values for entries {names[bad].tolist()}: "
+                    f"{values[bad].tolist()}. "
+                    "Expected 0 <= ra < 360, -90 <= dec <= 90, freq > 0 (MHz)."
+                )
+
+        # Status: "confirmed", "false_positive", "candidate" or "candidate_snrX"
+        status = self["absorber"]["status"][:]
+        bad = np.array(
+            [self._STATUS_RE.match(str(s)) is None for s in status], dtype=bool
+        )
+        if bad.any():
+            raise ValueError(
+                f"Invalid status values {np.unique(status[bad]).tolist()} for "
+                f"entries {names[bad].tolist()}. "
+                f"Allowed: {self.STATUS_VALUES}, where candidates may record "
+                "their detection S/N as 'candidate_snrX' (e.g. 'candidate_snr5')."
+            )
+
+        # Amplitude (optional):
+        amplitude = self["absorber"]["amplitude"][:]
+        bad = np.isinf(amplitude)
+        if bad.any():
+            raise ValueError(
+                f"Column 'amplitude' has non-finite (infinite) values for "
+                f"entries: {names[bad].tolist()}. Amplitude must be a finite "
+                "float, or NaN if unknown."
+            )
+
+    @property
+    def id(self) -> np.ndarray:
+        """The names/IDs of the absorbers."""
+        return self.index_map["object_id"]
+
+    @property
+    def ra(self) -> np.ndarray:
+        """Right ascension of each absorber."""
+        return self["position"]["ra"]
+
+    @property
+    def dec(self) -> np.ndarray:
+        """Declination of each absorber."""
+        return self["position"]["dec"]
+
+    @property
+    def freq(self) -> np.ndarray:
+        """Observed frequency (MHz) of the absorption feature."""
+        return self["absorber"]["freq"]
+
+    @property
+    def amplitude(self) -> np.ndarray:
+        """Estimated amplitude of the absorption feature (NaN if unknown)."""
+        return self["absorber"]["amplitude"]
+
+    @property
+    def status(self) -> np.ndarray:
+        """Status of each absorber (confirmed/candidate[_snrX]/false_positive)."""
+        return self["absorber"]["status"]
+
+    @property
+    def snr(self) -> np.ndarray:
+        """Detection S/N of each entry, parsed from the status (NaN if none)."""
+        return np.array([self._snr_of(s) for s in self["absorber"]["status"][:]])

--- a/ch_pipeline/hfb/io.py
+++ b/ch_pipeline/hfb/io.py
@@ -1,6 +1,7 @@
 """HFB tasks for reading and writing files."""
 
 import gc
+import json
 import os
 from pathlib import Path
 
@@ -8,12 +9,15 @@ import caput.astro.time as ctime
 import numpy as np
 from beam_model.formed import FFTFormedActualBeamModel
 from caput import config
+from caput.containers.tod import concatenate as _concatenate_time
 from caput.pipeline import exceptions
-from caput.pipeline.tasklib import io
+from caput.pipeline.tasklib import base, io
+from caput.util import mpitools
 from ch_ephem.observers import chime
 from ch_util.hfbcat import HFBCatalog
+from draco.core.io import get_telescope
 
-from .containers import HFBData, HFBReader
+from .containers import AbsorberCatalogue, HFBData, HFBReader
 
 
 class BeamSelectionMixin:
@@ -448,3 +452,277 @@ class LoadFiles(LoadFilesFromParams):
 
         # Call the baseclass setup to resolve any selections
         super().setup()
+
+
+class MakeAbsorberCatalogue(base.ContainerTask):
+    """Build an AbsorberCatalogue container from a JSON target list.
+
+    'ra' (degrees), 'dec' (degrees), 'freq' (MHz) and 'status' are required.
+    'amplitude' may be null or omitted (stored as NaN).
+
+    Status values: "confirmed", "false_positive", "control" (bright
+    continuum test sources like Cyg A), and candidates, where a candidate
+    records its detection S/N in the status itself, e.g. "candidate_snr5"
+    or "candidate_snr7".
+
+    Attributes
+    ----------
+    json_file : str
+        Path to the JSON target list.
+    status_include : list, optional
+        Only include entries whose status matches:
+        "confirmed"/"false_positive" match exactly; "candidate" matches
+        ALL candidates; "candidate_snrX" matches candidates with S/N >= X.
+        By default all entries are included.
+    """
+
+    json_file = config.Property(proptype=str)
+    status_include = config.Property(proptype=list, default=None)
+
+    _done = False
+
+    def process(self):
+        """Read the JSON file and return the catalogue container.
+
+        Returns
+        -------
+        cat : AbsorberCatalogue
+        """
+        if self._done:
+            raise exceptions.PipelineStopIteration
+        self._done = True
+
+        with open(self.json_file) as f:
+            data = json.load(f)
+
+        names, ras, decs, freqs, amps, statuses = [], [], [], [], [], []
+
+        for name, entry in data.items():
+            try:
+                status = str(entry["status"])
+                ra = float(entry["ra"])
+                dec = float(entry["dec"])
+                freq = float(entry["freq"])
+            except (KeyError, TypeError) as e:
+                raise RuntimeError(
+                    f"Entry {name} in {self.json_file} is missing or has an "
+                    f"invalid required key: {e}."
+                ) from e
+
+            # Filter on status ("candidate" = all candidates;
+            # "candidate_snrX" = candidates with S/N >= X)
+            if (
+                self.status_include
+                and not AbsorberCatalogue.status_match(
+                    status, self.status_include
+                ).any()
+            ):
+                continue
+
+            amp = entry.get("amplitude", None)
+            amp = np.nan if amp is None else float(amp)
+
+            names.append(str(name))
+            ras.append(ra)
+            decs.append(dec)
+            freqs.append(freq)
+            amps.append(amp)
+            statuses.append(status)
+
+        if not names:
+            raise RuntimeError(
+                f"No absorbers in {self.json_file} matched "
+                f"status_include={self.status_include}."
+            )
+
+        # Generate catalogue names from the sky position, as
+        # CHIME_<RA><+/-Dec> in whole degrees (e.g. CHIME_024+33).
+        # Entries that round to the same position get a numeric suffix
+        # to keep object_id unique.
+        cat_names = []
+        for ra, dec in zip(ras, decs):
+            base = f"CHIME_{round(ra) % 360:03d}{round(dec):+03d}"
+            cname = base
+            n = 1
+            while cname in cat_names:
+                n += 1
+                cname = f"{base}_{n}"
+            cat_names.append(cname)
+
+        # Build the catalogue container
+        cat = AbsorberCatalogue(object_id=np.array(cat_names, dtype="U64"))
+        cat["position"]["ra"][:] = np.array(ras)
+        cat["position"]["dec"][:] = np.array(decs)
+        cat["absorber"]["freq"][:] = np.array(freqs)
+        cat["absorber"]["amplitude"][:] = np.array(amps)
+        cat["absorber"]["status"][:] = np.array(statuses, dtype="U24")
+
+        cat.attrs["tag"] = Path(self.json_file).stem
+        cat.attrs["source_json"] = os.path.abspath(self.json_file)
+
+        # Raise on any invalid values before the catalogue is used/saved
+        cat.validate()
+
+        self.log.info(
+            f"Built AbsorberCatalogue with {len(names)}/{len(data)} entries "
+            f"from {self.json_file} (status_include={self.status_include})."
+        )
+
+        return cat
+
+
+class LoadFilesForAbsorbers(BaseLoadFiles):
+    """Load HFB data for the absorbers in a catalogue.
+
+    Works like LoadFiles but computes the frequency selection as the union
+    of the absorbers' frequency windows, loading only those channels, then
+    handing back one time-chunk per file group.
+
+    The absorber parameters are stored as arrays in each returned
+    container's attributes ('source_names', 'source_ra', 'source_dec',
+    'source_freq', 'source_status', 'source_amplitude') and are propagated
+    through the pipeline via 'attrs_from'.
+
+    Attributes
+    ----------
+    freq_phys_delta : float
+        Half-width of the frequency window (in MHz) to load around each
+        absorber frequency. Default is 0.4, giving 3-4 coarse channels
+        and guaranteeing coverage for the final +/- 390 kHz cutout window.
+    """
+
+    freq_phys_delta = config.Property(proptype=float, default=0.4)
+
+    _fgroup_ptr = 0
+
+    def setup(self, manager, filelists, catalogue):
+        """Parse the file groups, take the catalogue and set up the observer.
+
+        Parameters
+        ----------
+        filelists : list
+            A specification of the set of files for the day.
+        catalogue : AbsorberCatalogue
+            The catalogue of absorbers to load.
+        manager :
+            An Observer object holding the geographic location of the telescope.
+        """
+        self.observer = get_telescope(manager)
+
+        if not isinstance(filelists, list):
+            raise RuntimeError("Argument must be a list.")
+
+        self.filegroups = []
+        for flist in filelists:
+            if isinstance(flist, tuple):
+                fgroup = {"files": flist[0], "time_range": flist[1]}
+            elif isinstance(flist, list):
+                fgroup = {"files": flist, "time_range": (None, None)}
+            elif isinstance(flist, str | Path):
+                fgroup = {"files": [flist], "time_range": (None, None)}
+            else:
+                raise ValueError(
+                    f"Did not expect to get an object of type {type(flist)}"
+                )
+            # Avoid adding filegroups with empty filelists (the output of
+            # QueryDatabase with return_intervals can include days with no files)
+            if fgroup["files"]:
+                self.filegroups.append(fgroup)
+
+        self.log.info(f"Will iterate over {len(self.filegroups)} file groups.")
+
+        # Take the absorber parameters from the catalogue container
+        if not isinstance(catalogue, AbsorberCatalogue):
+            raise TypeError(f"Expected an AbsorberCatalogue, got {type(catalogue)}.")
+        catalogue.validate()
+
+        names = np.array([str(n) for n in catalogue.index_map["object_id"]])
+        freqs = np.asarray(catalogue["absorber"]["freq"][:])
+        freq_ax = np.linspace(800.0, 400.0, 1024, endpoint=False)
+
+        # Per-absorber coarse-channel windows
+        self._slices = []
+        for f0 in freqs:
+            i0 = int(np.argmin(np.abs(freq_ax - (f0 + self.freq_phys_delta))))
+            i1 = int(np.argmin(np.abs(freq_ax - (f0 - self.freq_phys_delta))))
+            self._slices.append(slice(min(i0, i1), max(i0, i1) + 1))
+
+        # Union of all absorber channel windows, as a sorted list of indices.
+        self.freq_sel = sorted(
+            {ch for sl in self._slices for ch in range(sl.start, sl.stop)}
+        )
+
+        self.log.info(
+            f"Catalogue has {len(names)} absorbers, {len(self.freq_sel)} total "
+            f"channels to distribute across {mpitools.size} MPI ranks."
+        )
+
+        self._source_names = names
+        self._source_ra = np.asarray(catalogue["position"]["ra"][:])
+        self._source_dec = np.asarray(catalogue["position"]["dec"][:])
+        self._source_freq = freqs
+        self._source_status = np.asarray(catalogue["absorber"]["status"][:])
+        self._source_amp = np.asarray(catalogue["absorber"]["amplitude"][:])
+
+    def process(self):
+        """Load the next file group for all absorbers.
+
+        Returns
+        -------
+        tstream : HFBData
+            One time-chunk with all absorbers' frequency channels
+            distributed across MPI ranks.
+        """
+        gc.collect()
+
+        if self._fgroup_ptr >= len(self.filegroups):
+            raise exceptions.PipelineStopIteration
+
+        filegroup = self.filegroups[self._fgroup_ptr]
+        self._fgroup_ptr += 1
+
+        self.log.info(f"Reading file group {self._fgroup_ptr}/{len(self.filegroups)}.")
+
+        time_range = filegroup.get("time_range", (None, None))
+
+        # Load each file into an HFBData container, applying the union
+        # frequency selection, then concatenate along the time axis
+        fgroup_containers = []
+        for fname in filegroup["files"]:
+            if not os.path.exists(fname):
+                raise RuntimeError(f"File does not exist: {fname}")
+            cont = HFBData.from_file(
+                fname,
+                distributed=self.distributed,
+                freq_sel=self.freq_sel,
+            )
+            fgroup_containers.append(cont)
+
+        tstream = (
+            _concatenate_time(fgroup_containers)
+            if len(fgroup_containers) > 1
+            else fgroup_containers[0]
+        )
+
+        # Redistribute so channels are evenly spread across MPI ranks
+        tstream.redistribute("freq")
+
+        # Find the time to use to compute the container's LSD
+        if time_range and time_range != (None, None):
+            container_time = float(np.mean(time_range))
+        else:
+            container_time = 0.5 * (float(tstream.time[0]) + float(tstream.time[-1]))
+
+        lsd = int(self.observer.unix_to_lsd(container_time))
+        tstream.attrs["lsd"] = lsd
+        tstream.attrs["tag"] = f"lsd_{lsd}"
+        tstream.attrs["files"] = filegroup["files"]
+
+        tstream.attrs["source_names"] = self._source_names
+        tstream.attrs["source_ra"] = self._source_ra
+        tstream.attrs["source_dec"] = self._source_dec
+        tstream.attrs["source_freq"] = self._source_freq
+        tstream.attrs["source_status"] = self._source_status
+        tstream.attrs["source_amplitude"] = self._source_amp
+
+        return tstream

--- a/ch_pipeline/hfb/sidereal.py
+++ b/ch_pipeline/hfb/sidereal.py
@@ -61,9 +61,8 @@ class HFBSiderealRegridder(SiderealRegridderLinear):
 
         # Massage down to a 3D array by combining the subfreq and beam axes;
         # this is to fit the expectations of the base class
-        lfreq, *_, ntime = hfb_data.shape
-        hfb_data = hfb_data.reshape(lfreq, -1, ntime)
-        weight = weight.reshape(lfreq, -1, ntime)
+        hfb_data = hfb_data.reshape(lfreq, nsubfreq * nbeam, ntime)
+        weight = weight.reshape(lfreq, nsubfreq * nbeam, ntime)
 
         # Perform regridding
         _, sts, ni = self._regrid(hfb_data, weight, timestamp_lsd)
@@ -96,7 +95,7 @@ class HFBSiderealRegridder(SiderealRegridderLinear):
         )
         sdata.redistribute("freq")
         sdata.attrs["lsd"] = self.start
-        sdata.attrs["tag"] = f"lsd_{self.start:d}"
+        sdata.attrs["tag"] = f"lsd_{int(self.start)}"
 
         # Put regridded data into output container, one beam at a time
         sh = sdata.hfb[:]


### PR DESCRIPTION
Add new tasks that produce one ringmap cutout per absorber per sidereal day for a given absorber catalogue (confirmed and candidates).

The list of new tasks and container
- hfb.containers.AbsorberCatalogue
- hfb.io.LoadFilesForAbsorbers
- hfb.io.MakeAbsorberCatalogue
- hfb.analysis.SelectBeamsAroundSources
- hfb.analysis.ExtractAbsroberCutouts